### PR TITLE
Scope feed.component.scss ion-icon rule to .actions

### DIFF
--- a/vendor/github.com/eaabak/ionTok/src/app/components/feed/feed.component.scss
+++ b/vendor/github.com/eaabak/ionTok/src/app/components/feed/feed.component.scss
@@ -12,7 +12,13 @@
   --ionicon-fill-color: red;    /* For filled icons */
 }
 
-ion-icon {
+// Scoped to .actions so it does NOT bleed onto every ion-icon in the
+// component. Originally `ion-icon { position: fixed; right: -5px; ... }`,
+// which broke the .star-rating widget by pinning every star to the same
+// off-screen-right coordinate (they stacked perfectly and looked like a
+// single star). The right-column icons (heart, bookmark, info) live
+// inside .actions and rely on this positioning.
+.actions ion-icon {
   color: white;
   height: 40px;
   width: 50px;


### PR DESCRIPTION
Follow-up to #5. After deploying the 5-star widget, only one star was visible on the live site.

## Diagnosis

The widget's 5 `<ion-icon>` elements live inside a `.star-rating` div with `display: flex; gap: 12px`. They were rendering (verified by grepping the deployed bundle), but the existing SCSS rule

\`\`\`scss
ion-icon {
  position: fixed;
  right: -5px;
  width: 50px;
  ...
  z-index: 9999 !important;
}
\`\`\`

is component-scoped to `<app-feed>` — which still means it matches **every** `<ion-icon>` in the component template. `position: fixed` removed all 5 stars from the parent's flex layout and pinned them to the same coordinate at the right edge of the viewport. They stacked perfectly on top of each other, looking like a single star.

## Fix

One-line selector change: `ion-icon` → `.actions ion-icon`. The right-column icons (heart, bookmark, info) all live inside `.actions` and rely on the `position: fixed; right: -5px` to float to the screen edge — that behaviour is preserved. The rule just stops leaking onto siblings.

## After merge

`music-k8s` bumps `TIK_ETH_TOK_REF` to this commit, frontend rebuilds, deploy, verify b.dastream.tv shows 5 stars side by side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)