### PR TITLE
Stop the /likes button from clobbering localStorage.account

### DIFF
--- a/vendor/github.com/eaabak/ionTok/src/app/components/feed/feed.component.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/components/feed/feed.component.ts
@@ -119,7 +119,10 @@ export class FeedComponent implements OnInit {
         console.log("feed.component.ts: buttonClicked !! setting Mark As Skipped to false")
         window.sessionStorage.setItem('markasskipped','false')
         window.sessionStorage.setItem('skipBack','false')
-        window.sessionStorage.setItem('account','droid')
+        // NOTE: removed `setItem('account','droid')`. localStorage.account
+        // now doubles as the session filter (which show to load); clobbering
+        // it on every like would break the filter and corrupt rating
+        // attribution (see music-k8s SESSIONS_AND_RATINGS.md).
       }
       else {
         console.log("feed.component.ts: buttonClicked !! setting Mark As Skipped to true")
@@ -167,12 +170,12 @@ export class FeedComponent implements OnInit {
     }).subscribe(
       response => {
         console.log('feed.component.ts: buttonClicked Request successful:', response);
-        window.localStorage.setItem('account','droid');
+        // NOTE: removed `setItem('account','droid')` here for the same reason
+        // as the session-set above. Auto-advance to the next slide stays.
         document.querySelector('ion-slides').slideNext();
       },
       error => {
         console.error('feed.component.ts: buttonClicked Request failed:', error);
-        window.localStorage.setItem('account','droid');
         document.querySelector('ion-slides').slideNext();
       }
     );


### PR DESCRIPTION
Minimal fix from the design doc's "Existing likes kludge" cleanup. Removes three sites in \`feed.component.ts buttonClicked('likes')\` that wrote the literal string \`'droid'\` into \`localStorage.account\` / \`sessionStorage.account\`.

\`localStorage.account\` now doubles as the session filter for the sessions/ratings change set, so clobbering it had two visible effects:

- The show-name filter on \`/videos\` started returning the wrong session (or zero rows) after any like-tap.
- Subsequent \`POST /videos/<id>/rating\` calls sent \`account_number='droid'\` instead of the user's show name, fragmenting per-user rating attribution.

**Diagnosed live**: a star tap on video 1566 recorded \`account=164-4-23-2025\` correctly; an intervening tap on the heart icon mutated the account; the next star tap on video 1567 then recorded \`account=droid\`.

## What this does NOT touch

This is the minimum-blast-radius fix. Intentionally left alone:

- The \`/likes\` endpoint itself.
- \`videos.userPic\` / \`videos.userName\` mutation by the backend's \`update_likes\`.
- The \`userPic NOT ILIKE 'Heart%'\` filter on \`/videos\`.
- The \`'99999'\` magic-account skip semantics.

A larger cleanup (remove the heart button, replace the kludge with a real per-user filter against \`user_interactions\`, drop the userPic mutation, switch the likes count to a computed COUNT) is its own follow-up.

After merge: pin bump in music-k8s, rebuild frontend, done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)