### PR TITLE
Bind searchbar placeholder to live "N videos left to rate" count

### DIFF
--- a/vendor/github.com/eaabak/ionTok/src/app/components/feed/feed.component.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/components/feed/feed.component.ts
@@ -139,13 +139,17 @@ export class FeedComponent implements OnInit {
 
       // Modify the <video> element
       const videoElement = document.getElementById('float') as HTMLVideoElement;
-      const searchElement = document.getElementById('search')
 
       if (videoElement) {
         videoElement.src = 'https://your.cmptr.cloud/pageflip.mp3'; // Update the video source
         videoElement.style.display = 'block'; // Make the video visible
         videoElement.play().catch((error) => console.error('Video playback failed:', error)); // Start playing the video
-        searchElement.setAttribute("placeholder","${video_id}")
+        // NOTE: removed `searchElement.setAttribute("placeholder","${video_id}")`.
+        // It was a buggy attempt to show the video id in the searchbar — the
+        // string was double-quoted so JS treated `${video_id}` as a literal.
+        // The placeholder is now data-bound in home.page.html via
+        // [placeholder]="searchPlaceholder" and updated by home.page
+        // refreshProgress() to show "N videos left to rate".
       }
     } else if (button === 'comments') {
       // Toggle the bookmark color (black when clicked)

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/home/home.page.html
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/home/home.page.html
@@ -103,7 +103,7 @@
     <!-- Add your iframe here -->
 
 
-  <ion-searchbar *ngIf="showSearchBar" #searchbar (keyup)="onSearchKeyup($event)" id="search" style="z-index: 9999;position: absolute; top: 45%; left: 0px;" placeholder="Search..."></ion-searchbar>
+  <ion-searchbar *ngIf="showSearchBar" #searchbar (keyup)="onSearchKeyup($event)" id="search" style="z-index: 9999;position: absolute; top: 45%; left: 0px;" [placeholder]="searchPlaceholder"></ion-searchbar>
 </div>
 </ion-content>
 

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/home/home.page.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/home/home.page.ts
@@ -41,6 +41,11 @@ export class HomePage implements OnInit {
   // Initialised to 0 (the intro slide).
   private lastSlideIndex: number = 0;
 
+  // Text shown in the searchbar's placeholder. Replaced by refreshProgress()
+  // with "N videos left to rate" once the backend has answered. Default is
+  // a generic hint so the bar doesn't look broken before the first response.
+  searchPlaceholder: string = 'Search to load a new session';
+
   chainName: string;
   showHeaderDiv: boolean;
   showControls: boolean = true; // Controls the visibility of the slider and button
@@ -168,6 +173,8 @@ export class HomePage implements OnInit {
     this.videoList = [];
     this.currentPage = 1;
     this.loadVideos();
+    // New session = new "left to rate" count; refresh the searchbar placeholder.
+    this.refreshProgress();
     this.presentToast(`Loaded ${loaded} videos for "${pattern}"`);
     // Snap to the first slide so the user sees the new content.
     try {
@@ -512,6 +519,9 @@ export class HomePage implements OnInit {
     }
     window.addEventListener('message', this.receiveMessage.bind(this), false);
     this.loadVideos();
+    // Populate searchPlaceholder with the per-session "N left to rate" count.
+    // Backend-side count; failure is silent.
+    this.refreshProgress();
     console.log('home.page.ts ngOnInit Page loaded');
     console.log('home.page.ts ngOnInit Page host: [' + window.location.host + ']');
     console.log('home.page.ts ngOnInit Page starts with tikethtok.app: [' + window.location.host.startsWith('tikethtok.app') + ']');
@@ -876,6 +886,30 @@ onFeedRated(videoId: number) {
     this.ratedThisPageLoad.add(videoId);
     console.log(`home.page.ts onFeedRated marked video ${videoId} as rated`);
   }
+  // Each rating decrements the remaining count; refresh the placeholder
+  // so the user sees progress immediately.
+  this.refreshProgress();
+}
+
+// Update the searchbar placeholder with the count of videos in the current
+// session that the user hasn't rated yet. Called on page load, after each
+// star tap, after each scroll-past skip, and after a /sessions/load completes.
+// Failures are intentionally silent — the placeholder just stays at whatever
+// it was, no toast or error UI for a cosmetic feature.
+refreshProgress() {
+  this.data.getSessionProgress().subscribe(
+    (resp) => {
+      if (resp && typeof resp.remaining === 'number') {
+        const n = resp.remaining;
+        this.searchPlaceholder = n === 1
+          ? '1 video left to rate'
+          : `${n} videos left to rate`;
+      }
+    },
+    (err) => {
+      console.error('home.page.ts refreshProgress failed:', err);
+    },
+  );
 }
 
 // Internal: if the user scrolled FORWARD past a video without tapping
@@ -899,7 +933,11 @@ private maybeRecordScrollPastSkip(prevIndex: number, newIndex: number) {
   // Mark BEFORE the request so rapid scrolling can't fire duplicates.
   this.ratedThisPageLoad.add(prevVideo.id);
   this.data.postRating(prevVideo.id, 0).subscribe(
-    () => console.log(`home.page.ts scroll-past 0 recorded for video ${prevVideo.id}`),
+    () => {
+      console.log(`home.page.ts scroll-past 0 recorded for video ${prevVideo.id}`);
+      // Skip counts toward "done", so refresh the placeholder.
+      this.refreshProgress();
+    },
     err => console.error(`home.page.ts scroll-past 0 failed for video ${prevVideo.id}`, err),
   );
 }

--- a/vendor/github.com/eaabak/ionTok/src/app/services/data.service.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/services/data.service.ts
@@ -263,6 +263,26 @@ export class DataService {
         return this.http.get<any>(apiUrl);
     }
 
+    // Count of videos in the active session this account hasn't yet rated
+    // or scrolled-past. Used by the searchbar placeholder to show
+    // "N videos left to rate". Returns of(null) if there's nothing to ask
+    // about (no session set yet) so the caller can leave the placeholder
+    // unchanged in that case.
+    getSessionProgress(): Observable<any> {
+        const account = window.localStorage.getItem('account');
+        if (!account) {
+            return of(null);
+        }
+        const protocol = window.location.protocol;
+        const host = window.location.hostname;
+        // `session` and `account_number` happen to be the same value today
+        // (one storage key doubles as both). If they ever diverge, split here.
+        const apiUrl = `${protocol}//${host}/sessions/progress` +
+                       `?session=${encodeURIComponent(account)}` +
+                       `&account_number=${encodeURIComponent(account)}`;
+        return this.http.get<any>(apiUrl);
+    }
+
     // Method to get trending videos
     getTrends() {
         const trends = [{


### PR DESCRIPTION
Replaces the buggy \`searchElement.setAttribute("placeholder","\${video_id}")\` (which was setting the literal text \`\${video_id}\` because double-quotes don't interpolate) with a live count of videos in the active session the user hasn't rated or scrolled past yet.

## Changes

- **feed.component.ts**: remove the broken setAttribute call (+ explanatory comment).
- **data.service.ts**: new \`getSessionProgress()\` method that calls \`GET /sessions/progress\` (the new backend endpoint in music-k8s [#18](https://github.com/nospaceleftondevice/music-k8s/pull/18)). Returns \`of(null)\` if no account is set so the caller doesn't fire a bad request.
- **home.page.ts**:
  - \`searchPlaceholder\` property (default \`"Search to load a new session"\`).
  - \`refreshProgress()\` helper. On success, sets \`searchPlaceholder\` to \`"N videos left to rate"\` (or \`"1 video left to rate"\`); on error, silent.
  - Called from \`ngOnInit\`, \`onFeedRated\`, \`maybeRecordScrollPastSkip\` (success branch), and \`onLoadComplete\`.
- **home.page.html**: \`placeholder="Search..."\` → \`[placeholder]="searchPlaceholder"\`.

## Soft launch

If the backend endpoint isn't deployed yet, the HTTP call returns 404, error handler logs to console silently, and the placeholder stays at the default. No broken UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)