### PR TITLE
ion-slides: longSwipes: false — one swipe = one slide

### DIFF
--- a/vendor/github.com/eaabak/ionTok/src/app/pages/home/home.page.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/home/home.page.ts
@@ -243,7 +243,14 @@ export class HomePage implements OnInit {
   }
 
   slideOpts = {
-    direction: 'vertical'
+    direction: 'vertical',
+    // longSwipes: false forces exactly ONE slide advance per swipe. The
+    // Swiper default (longSwipes: true) advances multiple slides on a fast
+    // or long drag and emits ionSlideDidChange for each intermediate slide.
+    // Our scroll-past hook fires per event, so a multi-slide swipe would
+    // record N skip-ratings (decrementing "videos left to rate" by N) for
+    // a single user gesture — observed as 419 → 417 from one swipe.
+    longSwipes: false,
   };
 
   // Map of Chain IDs to Chain Names


### PR DESCRIPTION
One-line config change: \`longSwipes: false\` on the ion-slides options.

Swiper's default \`longSwipes: true\` advances multiple slides on a fast or long drag and emits \`ionSlideDidChange\` once per intermediate slide. The scroll-past hook in \`home.page.onSlideDidChange\` records a \`rating=0\` per event, so a single user gesture decremented "videos left to rate" by N. Observed live: 419 → 417 from one swipe.

Setting \`longSwipes: false\` locks the slider to exactly one slide advance per swipe regardless of velocity or drag distance.

After merge: pin bump in music-k8s, rebuild frontend, done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)