### PR TITLE
data.service: pass account_number to /videos so backend can filter rated videos

### DIFF
--- a/vendor/github.com/eaabak/ionTok/src/app/services/data.service.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/services/data.service.ts
@@ -28,7 +28,12 @@ export class DataService {
             var protocol = window.location.protocol; // 'https:'
             var host = window.location.hostname;
             var url = protocol + '//' + host;
+            // account_number tells the backend who's asking, so it can
+            // filter out videos this user has already rated or skipped.
+            // Same value as `session` today (one storage key doubles as
+            // both); split if the keys ever diverge.
             const apiUrl = `${url}/videos?session=${encodeURIComponent(session)}` +
+                           `&account_number=${encodeURIComponent(session)}` +
                            `&page=${page}&limit=${limit}`;
 
             return this.http.get<any>(apiUrl).pipe(
@@ -88,7 +93,10 @@ export class DataService {
         }
         const protocol = window.location.protocol;
         const host = window.location.hostname;
+        // account_number filters out already-rated videos server-side
+        // (see comment in getVideoList).
         const apiUrl = `${protocol}//${host}/videos?session=${encodeURIComponent(session)}` +
+                       `&account_number=${encodeURIComponent(session)}` +
                        `&search=${encodeURIComponent(search)}&page=${page}&limit=${limit}`;
 
         return this.http.get<any>(apiUrl).pipe(


### PR DESCRIPTION
Two-line change: append \`&account_number=…\` to the URL in both \`getVideoList\` and \`searchVideos\`. Value is the same as \`session\` today (one localStorage key doubles as both per the SESSIONS_AND_RATINGS design).

## Why

The downstream backend [music-k8s #21](https://github.com/nospaceleftondevice/music-k8s/pull/21) uses \`account_number\` on /videos to filter out rows the user has already rated or scrolled-past. Without it, /videos served the same N videos repeatedly even after the user rated them — the "stuck at 413 left, but keep seeing the same videos" symptom.

## Soft-launch

Backend made the param optional during the transition. If this PR ships before the backend's deployed, the frontend just sends a param the backend ignores. Safe in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)