### PR TITLE
Disable dastream.cloud WebSocket connection in home.page ngOnInit

### DIFF
--- a/vendor/github.com/eaabak/ionTok/src/app/pages/home/home.page.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/home/home.page.ts
@@ -498,7 +498,17 @@ export class HomePage implements OnInit {
   }
 
   ngOnInit() {
-    this.initializeWebSocket();
+    // Disabled: handleWebSocketMessage was treating every incoming WS
+    // message as a remote-control signal — calling slideNext/slidePrev,
+    // synthesizing clicks on the heart icon (which trips the /likes
+    // kludge, clobbers videos.userPic, and hides videos from the feed),
+    // and re-mutating localStorage.account to 'droid'. With other tabs
+    // potentially connected to wss://dastream.cloud/ws, this caused
+    // random-feeling slide jumps and per-swipe count drops > 1. The
+    // music app has no use for cross-device remote control today, so
+    // skip the connection entirely. Re-enable when remote mode is
+    // properly gated (separate UI toggle, dedicated remote host, etc.).
+    // this.initializeWebSocket();
     window.sessionStorage.setItem("next","");
     window.sessionStorage.setItem('viewbookmarks',"false");
     window.sessionStorage.removeItem("videoResults");


### PR DESCRIPTION
One-line fix: comment out \`this.initializeWebSocket()\` in \`ngOnInit\`.

\`handleWebSocketMessage\` was treating every incoming WS message as a remote-control signal — doing things the music app's flow doesn't want:

- **\`'next_slide'\`** → \`slideNext\`/\`slidePrev\` (random-feeling slide jumps, sometimes walking the user back to slide 0)
- **\`'like'\`** → synthesize a click on the heart icon's \`<div id=...>\`, which runs through \`buttonClicked('likes')\` → POST \`/likes\` → mutates \`videos.userPic\` to \`'Heart'\` → video disappears from the feed → \`/sessions/progress\` total drops, so "videos left to rate" decremented **independently of the user's actual swipes**
- \`'like'\` also re-set \`localStorage.account = 'droid'\` (we removed the same line from the buttonClicked path in #8, but this WS-side setter was a separate site doing the same thing)

Net symptom: one user swipe could decrement "videos left" by 2 (real scroll-past + a WS-triggered fake like landing nearby), and the app would occasionally jump to slide 0 from accumulated \`slidePrev\` calls.

Re-enabling is a one-line revert — the handler functions all stay defined; we just don't open the connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)