### PR TITLE
Add /matrix page: ranked pair list + heat-map matrix per session

### DIFF
--- a/vendor/github.com/eaabak/ionTok/src/app/app-routing.module.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/app-routing.module.ts
@@ -33,6 +33,15 @@ const routes: Routes = [
   {
     path: 'settings-and-privacy',
     loadChildren: () => import('./pages/settings-and-privacy/settings-and-privacy.module').then(m => m.SettingsAndPrivacyPageModule)
+  },
+  {
+    // Lazy-loaded matrix page. Reachable directly via /matrix or via a
+    // future link from the home page. Calls GET /sessions/<name>/matrix
+    // (defined in music-k8s backend); the SPA route name `matrix` doesn't
+    // collide with any backend path because backend paths sit under
+    // /sessions/<name>/matrix.
+    path: 'matrix',
+    loadChildren: () => import('./pages/matrix/matrix.module').then(m => m.MatrixPageModule)
   }
 ];
 @NgModule({

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix-routing.module.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { MatrixPage } from './matrix.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: MatrixPage
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class MatrixPageRoutingModule {}

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.module.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { IonicModule } from '@ionic/angular';
+
+import { MatrixPageRoutingModule } from './matrix-routing.module';
+
+import { MatrixPage } from './matrix.page';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    MatrixPageRoutingModule
+  ],
+  declarations: [MatrixPage]
+})
+export class MatrixPageModule {}

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.html
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.html
@@ -1,0 +1,109 @@
+<ion-header>
+  <ion-toolbar color="dark">
+    <ion-title>Matrix — {{ session || '(no session)' }}</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <!--
+    Search bar. Same UX as home.page: type a session name, hit Enter, the
+    page reloads for that session. Persists to localStorage.account so the
+    selection sticks across reloads and matches the home-feed filter.
+  -->
+  <div class="search-row">
+    <ion-searchbar
+      [(ngModel)]="searchTerm"
+      (keyup)="onSearchKeyup($event)"
+      placeholder="Session name (e.g. Sun-May-24-26)"
+      show-clear-button="focus">
+    </ion-searchbar>
+  </div>
+
+  <!-- Stats / loading / error banner -->
+  <div class="status-line" *ngIf="loading || errorMessage || stats">
+    <span *ngIf="loading">Loading…</span>
+    <span *ngIf="errorMessage" class="error">Error: {{ errorMessage }}</span>
+    <span *ngIf="stats && !loading && !errorMessage">
+      {{ stats.rated_with_urls }} rated mixes with URLs &middot;
+      {{ stats.rated_missing_urls }} missing URLs &middot;
+      {{ stats.extraction_pending }} pending extraction &middot;
+      {{ stats.total }} total videos in session
+    </span>
+  </div>
+
+  <!-- Pair list — the actionable view. Tap a row to open both URLs. -->
+  <section class="pairs" *ngIf="pairs.length">
+    <h2>Top mixes (sorted by rating)</h2>
+    <table class="pair-table">
+      <thead>
+        <tr>
+          <th class="col-rating">Rating</th>
+          <th class="col-url">URL A</th>
+          <th class="col-url">URL B</th>
+          <th class="col-file">File</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let p of pairs">
+          <td class="col-rating">
+            <span class="dot"
+                  [style.background]="ratingColor(p.rating)"
+                  [class.bordered]="p.rating === 0">
+              <span class="dot-num">{{ p.rating }}</span>
+            </span>
+          </td>
+          <td class="col-url">
+            <a (click)="openUrl(p.xUrl)">{{ p.xShort }}</a>
+          </td>
+          <td class="col-url">
+            <a (click)="openUrl(p.yUrl)">{{ p.yShort }}</a>
+          </td>
+          <td class="col-file">{{ p.filename }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- Heat-map matrix. Both axes carry the same URL list (deduplicated,
+       sorted by per-URL mean rating descending). Empty cells = no mix
+       for that pair. Rated=0 = white circle with thin border. Otherwise
+       solid colored dot. -->
+  <section class="matrix" *ngIf="axisUrls.length">
+    <h2>Pair matrix</h2>
+    <div class="matrix-scroll">
+      <table class="matrix-table">
+        <thead>
+          <tr>
+            <th class="corner"></th>
+            <th class="col-label" *ngFor="let s of axisShort">
+              <div class="rot">{{ s }}</div>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let row of matrix; let i = index">
+            <th class="row-label">{{ axisShort[i] }}</th>
+            <td *ngFor="let cell of row" class="cell">
+              <span class="dot"
+                    *ngIf="cellHasDot(cell.rating)"
+                    [style.background]="cellColor(cell.rating)"
+                    [class.bordered]="cellNeedsBorder(cell.rating)">
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- Empty state. -->
+  <div class="empty" *ngIf="!loading && !errorMessage && session && !pairs.length">
+    No rated mixes with extracted pair URLs found for
+    <strong>{{ session }}</strong>. Rate some videos on the home page; the
+    matrix will populate as URLs are extracted.
+  </div>
+
+  <div class="empty" *ngIf="!session && !loading">
+    Enter a session name above to load its matrix.
+  </div>
+</ion-content>

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.scss
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.scss
@@ -1,0 +1,179 @@
+// ---- layout shell ----
+.search-row {
+  padding: 4px 8px;
+}
+
+.status-line {
+  font-size: 13px;
+  color: #666;
+  padding: 0 16px 8px;
+}
+
+.status-line .error {
+  color: #b71c1c;
+  font-weight: 600;
+}
+
+.empty {
+  padding: 32px 16px;
+  color: #555;
+  text-align: center;
+}
+
+section {
+  padding: 8px 16px 24px;
+}
+
+section h2 {
+  font-size: 16px;
+  margin: 8px 0;
+  color: #222;
+}
+
+// ---- pair list ----
+.pair-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.pair-table th,
+.pair-table td {
+  text-align: left;
+  padding: 6px 8px;
+  border-bottom: 1px solid #eee;
+  vertical-align: middle;
+}
+
+.pair-table th {
+  font-weight: 600;
+  color: #444;
+  background: #fafafa;
+}
+
+.col-rating {
+  width: 56px;
+  text-align: center !important;
+}
+
+.col-url a {
+  color: #1565c0;
+  cursor: pointer;
+  text-decoration: none;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.col-url a:hover {
+  text-decoration: underline;
+}
+
+.col-file {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: #777;
+  font-size: 11px;
+}
+
+// ---- rating dots (shared by pair list + matrix) ----
+.dot {
+  display: inline-block;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  vertical-align: middle;
+  line-height: 22px;
+  text-align: center;
+}
+
+.dot.bordered {
+  border: 1px solid #222;
+}
+
+.dot-num {
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  text-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
+}
+
+// ---- matrix ----
+.matrix-scroll {
+  // The matrix can grow well past viewport for big sessions. Scroll both
+  // axes; the row/column headers stay readable thanks to position: sticky.
+  overflow: auto;
+  max-height: 80vh;
+  border: 1px solid #eee;
+  background: #fff;
+}
+
+.matrix-table {
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 11px;
+}
+
+.matrix-table th,
+.matrix-table td {
+  border: 1px solid #f0f0f0;
+}
+
+.matrix-table thead th {
+  position: sticky;
+  top: 0;
+  background: #fafafa;
+  z-index: 2;
+}
+
+.matrix-table .row-label {
+  position: sticky;
+  left: 0;
+  background: #fafafa;
+  z-index: 1;
+  text-align: right;
+  padding: 4px 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  white-space: nowrap;
+  // Slight color cue so the sticky row label visibly separates from cells.
+  border-right: 1px solid #ddd;
+}
+
+.matrix-table .corner {
+  position: sticky;
+  left: 0;
+  top: 0;
+  z-index: 3;
+  background: #fafafa;
+}
+
+.col-label {
+  // Column labels are URL shorts (~11 chars). Rotate so they don't widen
+  // every column. .rot gets the actual transform.
+  height: 96px;
+  padding: 0;
+  width: 28px;
+}
+
+.col-label .rot {
+  // -60deg keeps the text mostly horizontal but tilted up, which reads
+  // better at small sizes than full 90deg.
+  transform-origin: bottom left;
+  transform: rotate(-60deg) translate(8px, -8px);
+  white-space: nowrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: #444;
+}
+
+.cell {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  text-align: center;
+  vertical-align: middle;
+  background: #fff;
+}
+
+.cell .dot {
+  width: 16px;
+  height: 16px;
+  line-height: 16px;
+}

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.ts
@@ -1,0 +1,297 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { ToastController } from '@ionic/angular';
+
+/**
+ * MatrixPage — visualises the user's ratings for a session as:
+ *
+ *   1. A ranked list of pairs (best mixes at the top), and
+ *   2. An NxN heat-map matrix indexed by the source YouTube URLs.
+ *
+ * Backend feed: `GET /sessions/<name>/matrix?account_number=<x>`. Returns
+ * each video in the session with its rating + extracted (x_url, y_url)
+ * pair URLs. Videos that haven't been rated, or that have no extracted
+ * URLs (extraction failed / no `network` tag in the mp4), are silently
+ * skipped — the page is for actionable show-curation, not a complete
+ * audit of the session.
+ *
+ * The search bar at top behaves like home.page's: typing a session name
+ * and pressing Enter reloads the matrix for that session. localStorage
+ * 'account' doubles as the default and as the matrix's account_number
+ * (matches the convention used everywhere else in this app).
+ */
+
+interface MatrixVideo {
+  id: number;
+  url: string;
+  filename: string;
+  x_url: string | null;
+  y_url: string | null;
+  metadata_extracted_at: string | null;
+  rating: number | null;
+}
+
+interface MatrixStats {
+  total: number;
+  rated: number;
+  rated_with_urls: number;
+  rated_missing_urls: number;
+  extraction_pending: number;
+}
+
+interface MatrixResponse {
+  session: string;
+  account_number: string;
+  videos: MatrixVideo[];
+  stats: MatrixStats;
+}
+
+interface PairRow {
+  videoId: number;
+  filename: string;
+  xUrl: string;
+  yUrl: string;
+  xShort: string;
+  yShort: string;
+  rating: number;
+}
+
+interface MatrixCell {
+  rating: number | null;  // null = no mix at this pair
+  videoIds: number[];     // 0+ videos at this pair
+}
+
+@Component({
+  selector: 'app-matrix',
+  templateUrl: './matrix.page.html',
+  styleUrls: ['./matrix.page.scss'],
+})
+export class MatrixPage implements OnInit {
+  session: string = '';
+  searchTerm: string = '';
+  loading: boolean = false;
+  errorMessage: string = '';
+  stats: MatrixStats | null = null;
+
+  // The actionable view: every (x, y, rating) where both URLs are present
+  // and the user rated it, sorted by rating descending.
+  pairs: PairRow[] = [];
+
+  // The matrix view. axisUrls is the ordered list of unique source URLs
+  // (both axes share the same ordering — the relation is symmetric).
+  // axisShort is the truncated label shown on the axis. matrix[i][j] is
+  // the cell for (axisUrls[i], axisUrls[j]).
+  axisUrls: string[] = [];
+  axisShort: string[] = [];
+  matrix: MatrixCell[][] = [];
+
+  constructor(
+    private http: HttpClient,
+    private toastController: ToastController,
+  ) {}
+
+  ngOnInit() {
+    // Default the search field + the loaded session to whatever the home
+    // page is currently working with. If localStorage.account is unset
+    // we just render the empty state until the user types a session.
+    const stored = window.localStorage.getItem('account');
+    if (stored) {
+      this.searchTerm = stored;
+      this.session = stored;
+      this.refresh();
+    }
+  }
+
+  /** Submit handler for the searchbar. Reloads for the typed session. */
+  onSearchKeyup(event: KeyboardEvent) {
+    if (event.key !== 'Enter' && event.key !== 'Return') {
+      return;
+    }
+    const term = ((event.target as HTMLInputElement).value || '').trim();
+    if (!term) {
+      return;
+    }
+    this.session = term;
+    // Persist so reload + the home page agree on which session is active.
+    window.localStorage.setItem('account', term);
+    this.refresh();
+  }
+
+  refresh() {
+    if (!this.session) {
+      return;
+    }
+    this.loading = true;
+    this.errorMessage = '';
+    const url =
+      `/sessions/${encodeURIComponent(this.session)}/matrix` +
+      `?account_number=${encodeURIComponent(this.session)}`;
+    this.http.get<MatrixResponse>(url).subscribe(
+      (resp) => {
+        this.stats = resp.stats;
+        this.build(resp.videos);
+        this.loading = false;
+      },
+      (err) => {
+        console.error('matrix.page: load failed', err);
+        this.errorMessage =
+          (err && err.error && err.error.error) || 'failed to load matrix';
+        this.pairs = [];
+        this.axisUrls = [];
+        this.matrix = [];
+        this.loading = false;
+      },
+    );
+  }
+
+  /**
+   * Build the pair list AND the heat-map matrix from the raw video list.
+   * Filters to rated videos with both URLs extracted — the rest aren't
+   * actionable for this page.
+   */
+  private build(videos: MatrixVideo[]) {
+    // 1. The actionable subset.
+    const actionable = videos.filter(
+      (v) =>
+        v.rating !== null &&
+        typeof v.x_url === 'string' &&
+        typeof v.y_url === 'string' &&
+        v.x_url &&
+        v.y_url,
+    );
+
+    // 2. Pair list — sorted by rating desc, then by video id for stability.
+    this.pairs = actionable
+      .map((v) => ({
+        videoId: v.id,
+        filename: v.filename,
+        xUrl: v.x_url!,
+        yUrl: v.y_url!,
+        xShort: shortenYouTube(v.x_url!),
+        yShort: shortenYouTube(v.y_url!),
+        rating: v.rating!,
+      }))
+      .sort((a, b) => b.rating - a.rating || a.videoId - b.videoId);
+
+    // 3. Unique URLs across both axes (matrix is symmetric — a song
+    //    paired with itself isn't a real mix, so the diagonal stays empty).
+    const urlSet = new Set<string>();
+    for (const v of actionable) {
+      urlSet.add(v.x_url!);
+      urlSet.add(v.y_url!);
+    }
+    const allUrls = Array.from(urlSet);
+
+    // 4. Sort axis by per-URL mean rating descending so the hottest songs
+    //    cluster at the top-left. (Heat-map-style "highest in the middle"
+    //    reordering would mean sort-by-mean then re-permute toward center;
+    //    skipping for now — descending sort already groups high ratings
+    //    in the top-left quadrant, which scans clearly enough at ~30 URLs.)
+    const meanByUrl = new Map<string, number>();
+    for (const u of allUrls) {
+      const ratings: number[] = [];
+      for (const v of actionable) {
+        if (v.x_url === u || v.y_url === u) ratings.push(v.rating!);
+      }
+      meanByUrl.set(
+        u,
+        ratings.reduce((a, b) => a + b, 0) / Math.max(1, ratings.length),
+      );
+    }
+    allUrls.sort((a, b) => (meanByUrl.get(b)! - meanByUrl.get(a)!));
+
+    this.axisUrls = allUrls;
+    this.axisShort = allUrls.map(shortenYouTube);
+
+    // 5. Empty NxN matrix.
+    const n = allUrls.length;
+    const cells: MatrixCell[][] = [];
+    for (let i = 0; i < n; i++) {
+      const row: MatrixCell[] = [];
+      for (let j = 0; j < n; j++) {
+        row.push({ rating: null, videoIds: [] });
+      }
+      cells.push(row);
+    }
+
+    // 6. Place each video. The pair is unordered (a mix of A+B is the
+    //    same musical pairing as B+A), so we update BOTH (i,j) and (j,i).
+    //    If multiple mixes exist for the same pair, keep the HIGHEST
+    //    rating — the user is picking the best, not averaging.
+    const idx = new Map<string, number>();
+    allUrls.forEach((u, i) => idx.set(u, i));
+    for (const v of actionable) {
+      const i = idx.get(v.x_url!)!;
+      const j = idx.get(v.y_url!)!;
+      for (const [a, b] of [[i, j], [j, i]] as [number, number][]) {
+        const cell = cells[a][b];
+        cell.videoIds.push(v.id);
+        if (cell.rating === null || v.rating! > cell.rating) {
+          cell.rating = v.rating!;
+        }
+      }
+    }
+    this.matrix = cells;
+  }
+
+  /** Color spec from the user's design: 0..5 + null. */
+  cellColor(rating: number | null): string {
+    if (rating === null) return 'transparent';  // no mix at this cell
+    if (rating === 0) return '#ffffff';          // skipped — white circle, thin border
+    if (rating === 1) return '#1565c0';          // blue
+    if (rating === 2) return '#42a5f5';          // light blue
+    if (rating === 3) return '#fb8c00';          // orange
+    if (rating === 4) return '#fdd835';          // yellow
+    if (rating === 5) return '#e53935';          // red
+    return 'transparent';
+  }
+
+  /** Empty cells (no mix) render as nothing; rated=0 still gets a white
+   *  circle with a thin border. Anything else is a solid colored disc. */
+  cellNeedsBorder(rating: number | null): boolean {
+    return rating === 0;
+  }
+
+  cellHasDot(rating: number | null): boolean {
+    return rating !== null;
+  }
+
+  /** Used by the pair-list rating badge — same colors as cellColor but
+   *  with white default so the badge always renders something. */
+  ratingColor(rating: number): string {
+    return this.cellColor(rating);
+  }
+
+  /** Toast helper for action feedback (copy-url, etc.) */
+  async toast(message: string) {
+    const t = await this.toastController.create({
+      message,
+      duration: 1500,
+      position: 'bottom',
+    });
+    t.present();
+  }
+
+  /** Trivially "open the URL in a new tab" for pair-list clicks. */
+  openUrl(url: string) {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  }
+}
+
+
+/**
+ * Best-effort URL shortener for YouTube links. Returns the 11-char video
+ * id when we can extract one (the part after `v=` or after `youtu.be/`),
+ * else the last 11 chars of the URL. Keeps axis labels narrow.
+ */
+function shortenYouTube(url: string): string {
+  if (!url) return '';
+  // youtu.be/<id>?optional-query
+  const shortMatch = url.match(/youtu\.be\/([A-Za-z0-9_-]{11})/);
+  if (shortMatch) return shortMatch[1];
+  // youtube.com/watch?v=<id>
+  const longMatch = url.match(/[?&]v=([A-Za-z0-9_-]{11})/);
+  if (longMatch) return longMatch[1];
+  // Fallback: last 11 chars (matches the YouTube id length).
+  return url.slice(-11);
+}


### PR DESCRIPTION
New lazy-loaded Ionic route at \`/matrix\`. Renders two views per session:

1. **Ranked pair list** — best mixes at the top, sorted by rating descending. Columns: rating circle, x_url, y_url, filename. Tap a URL to open it in a new tab.
2. **NxN heat-map matrix** — both axes are the deduplicated source URLs, sorted by per-URL mean rating descending so the hottest songs cluster at the top-left. Each cell is a colored circle for the rating of the mix made from that pair, blank if no mix exists.

Data comes from \`GET /sessions/<name>/matrix?account_number=<x>\` (music-k8s backend). Videos without extracted pair URLs are silently skipped — this page is for curation, not a full session audit.

## Color spec (your design)

| Rating | Color |
|---|---|
| no rating | empty cell |
| 0 (skip) | white circle, thin black border |
| 1 | blue |
| 2 | light blue |
| 3 | orange |
| 4 | yellow |
| 5 | red |

## UX notes

- Search bar at top behaves identically to home page: type session name + Enter → reloads. Persists to \`localStorage.account\`, so the home and matrix pages stay in sync.
- URLs are shortened to the 11-char YouTube video id for axis labels (full URL is the click target).
- Matrix is symmetric — a mix of A+B and B+A is the same pairing, so both cells get populated. Multiple mixes for the same pair keep the highest rating (you're picking the best, not averaging).
- Sticky row + column headers, both axes scroll, max-height 80vh.

## Files

\`\`\`
pages/matrix/matrix.module.ts          # NgModule scaffolding
pages/matrix/matrix-routing.module.ts  # forChild routes
pages/matrix/matrix.page.ts            # component + build/sort/render logic
pages/matrix/matrix.page.html          # template
pages/matrix/matrix.page.scss          # table + dot styling
app-routing.module.ts                  # +matrix lazy route
\`\`\`

No backend, ingress, or terraform change needed — the SPA nginx fallback covers \`/matrix\` already and the \`/sessions\` ingress rule already routes the data API.

## After merge

Pin bump in music-k8s, frontend rebuild, then visit https://b.dastream.tv/matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)