### PR TITLE
matrix: dark theme so the rating colors pop

### DIFF
--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.scss
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.scss
@@ -1,3 +1,36 @@
+// ---- dark-theme palette ----
+//
+// The user asked for a black background so the colored rating dots pop.
+// Cell border color stays as-is (#f3f3f3) per the same ask — on a black
+// background the light gray grid lines are visible and define the cells
+// without competing with the dots.
+//
+// Text colors are all light variants of gray/white so they read against
+// the black backdrop. Sticky header backgrounds use opaque-black so cells
+// don't visibly show through when scrolling.
+$bg:              #000;
+$bg-elevated:     #111;  // pair-list header rows, sticky matrix headers
+$border-subtle:   #333;  // dividers between sections / pair-list rows
+$text-primary:    #eaeaea;
+$text-secondary:  #aaa;
+$text-muted:      #777;
+$link:            #6cb1ff;
+$link-hover:      #98c8ff;
+
+// ion-content provides its own background; override via the documented
+// CSS variables so the whole page sits on $bg.
+:host {
+  --ion-background-color: #{$bg};
+  --ion-text-color: #{$text-primary};
+  color: $text-primary;
+  background: $bg;
+}
+
+ion-content {
+  --background: #{$bg};
+  --color: #{$text-primary};
+}
+
 // ---- layout shell ----
 .search-row {
   padding: 4px 8px;
@@ -5,18 +38,18 @@
 
 .status-line {
   font-size: 13px;
-  color: #666;
+  color: $text-secondary;
   padding: 0 16px 8px;
 }
 
 .status-line .error {
-  color: #b71c1c;
+  color: #ef5350;  // bright red, still legible on black
   font-weight: 600;
 }
 
 .empty {
   padding: 32px 16px;
-  color: #555;
+  color: $text-secondary;
   text-align: center;
 }
 
@@ -27,7 +60,7 @@ section {
 section h2 {
   font-size: 16px;
   margin: 8px 0;
-  color: #222;
+  color: $text-primary;
 }
 
 // ---- pair list ----
@@ -35,20 +68,21 @@ section h2 {
   width: 100%;
   border-collapse: collapse;
   font-size: 13px;
+  color: $text-primary;
 }
 
 .pair-table th,
 .pair-table td {
   text-align: left;
   padding: 6px 8px;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid $border-subtle;
   vertical-align: middle;
 }
 
 .pair-table th {
   font-weight: 600;
-  color: #444;
-  background: #fafafa;
+  color: $text-secondary;
+  background: $bg-elevated;
 }
 
 .col-rating {
@@ -57,19 +91,20 @@ section h2 {
 }
 
 .col-url a {
-  color: #1565c0;
+  color: $link;
   cursor: pointer;
   text-decoration: none;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .col-url a:hover {
+  color: $link-hover;
   text-decoration: underline;
 }
 
 .col-file {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  color: #777;
+  color: $text-muted;
   font-size: 11px;
 }
 
@@ -84,8 +119,11 @@ section h2 {
   text-align: center;
 }
 
+// rated=0 ("skipped") renders as a white circle with a thin border per
+// the original spec. Border color flipped to white so it's visible on
+// the black page background.
 .dot.bordered {
-  border: 1px solid #222;
+  border: 1px solid $text-primary;
 }
 
 .dot-num {
@@ -109,8 +147,8 @@ $matrix-row-label-width: 96px;
   // Row/column headers stay visible via position: sticky.
   overflow: auto;
   max-height: 80vh;
-  border: 1px solid #eee;
-  background: #fff;
+  border: 1px solid $border-subtle;
+  background: $bg;
 }
 
 .matrix-table {
@@ -125,30 +163,36 @@ $matrix-row-label-width: 96px;
 
 .matrix-table th,
 .matrix-table td {
+  // Cell border color intentionally kept at #f3f3f3 per user request.
+  // On the black background these light gray grid lines read as a faint
+  // graph paper backdrop — exactly the right amount of structure to make
+  // the colored dots pop without competing with them.
   border: 1px solid #f3f3f3;
   // Hard cap so an overly long URL label can't push a cell wider.
   box-sizing: border-box;
 }
 
-// Sticky top row (column labels).
+// Sticky top row (column labels). Opaque-black so cells don't show
+// through when scrolling vertically.
 .matrix-table thead th {
   position: sticky;
   top: 0;
-  background: #fafafa;
+  background: $bg-elevated;
   z-index: 2;
 }
 
-// Sticky left column (row labels). The fix for "y-axis not visible":
-// give it an explicit width (table-layout: fixed needs this) and a
-// bigger z-index so it overlays cells properly while scrolling right.
-// Border-right gives a clean visual separator.
+// Sticky left column (row labels). Explicit width + table-layout: fixed
+// (above) keeps the column from collapsing. Opaque-black bg so cells
+// don't show through when scrolling horizontally. Light text so the
+// URL slug is readable.
 .matrix-table .row-label {
   position: sticky;
   left: 0;
   width: $matrix-row-label-width;
   min-width: $matrix-row-label-width;
   max-width: $matrix-row-label-width;
-  background: #fafafa;
+  background: $bg-elevated;
+  color: $text-primary;
   z-index: 2;
   text-align: right;
   padding: 0 6px;
@@ -157,7 +201,7 @@ $matrix-row-label-width: 96px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  border-right: 1px solid #c8c8c8;
+  border-right: 1px solid $border-subtle;
   // Match the cell height so rows stay on a tight grid.
   height: $matrix-cell;
   line-height: $matrix-cell;
@@ -173,9 +217,9 @@ $matrix-row-label-width: 96px;
   min-width: $matrix-row-label-width;
   max-width: $matrix-row-label-width;
   z-index: 3;
-  background: #fafafa;
-  border-right: 1px solid #c8c8c8;
-  border-bottom: 1px solid #c8c8c8;
+  background: $bg-elevated;
+  border-right: 1px solid $border-subtle;
+  border-bottom: 1px solid $border-subtle;
 }
 
 .col-label {
@@ -196,7 +240,7 @@ $matrix-row-label-width: 96px;
   white-space: nowrap;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 10px;
-  color: #444;
+  color: $text-primary;
 }
 
 .cell {
@@ -207,7 +251,9 @@ $matrix-row-label-width: 96px;
   padding: 0;
   text-align: center;
   vertical-align: middle;
-  background: #fff;
+  // Empty cells stay black so only the borders + colored dots are
+  // visible. Rated cells override via inline style on the .dot inside.
+  background: $bg;
 }
 
 .cell .dot {
@@ -215,4 +261,3 @@ $matrix-row-label-width: 96px;
   height: $matrix-dot;
   line-height: $matrix-dot;
 }
-


### PR DESCRIPTION
Page background flipped to black per user's ask. The colored rating dots (blue / light blue / orange / yellow / red) are much more visually distinct against black than against white. Cell border color **intentionally kept at \`#f3f3f3\`** per the same ask — those light gray grid lines read as a faint graph-paper backdrop on black, defining the cells without competing with the dots.

## Color sweep

| Surface | Before | After |
|---|---|---|
| Page bg | white | black (\`#000\`) |
| Sticky headers / pair-list header row | \`#fafafa\` | \`#111\` |
| Primary text (titles, labels, body) | dark | \`#eaeaea\` |
| Secondary text (status, empty state) | \`#555\`–\`#666\` | \`#aaa\` |
| Links (URL anchors) | \`#1565c0\` | \`#6cb1ff\` |
| Error text | \`#b71c1c\` | \`#ef5350\` (brighter red) |
| Section/row dividers | \`#eee\`/\`#ddd\` | \`#333\` |
| Cell borders | \`#f3f3f3\` | **unchanged** (your request) |
| \`rated=0\` circle border | \`#222\` | \`#eaeaea\` (so the white dot is visible on black) |

## Plumbing

- ion-content's \`--background\` and \`--color\` set via \`:host\` so the whole page (not just inner sections) renders dark.
- Sticky header backgrounds use \`$bg-elevated\` (\`#111\`) so they're opaque and cells don't show through during scroll.
- Empty cells stay pure black so only the borders + colored dots draw the eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)