### PR TITLE
matrix: drop grid lines + show matrix above the pair list

### DIFF
--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.html
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.html
@@ -31,7 +31,41 @@
     </span>
   </div>
 
-  <!-- Pair list — the actionable view. Tap a row to open both URLs. -->
+  <!-- Heat-map matrix. Both axes carry the same URL list (deduplicated,
+       sorted by per-URL mean rating descending). Empty cells = no mix
+       for that pair. Rated=0 = white circle with thin border. Otherwise
+       solid colored dot. Rendered FIRST so it's above the fold. -->
+  <section class="matrix" *ngIf="axisUrls.length">
+    <h2>Pair matrix</h2>
+    <div class="matrix-scroll">
+      <table class="matrix-table">
+        <thead>
+          <tr>
+            <th class="corner"></th>
+            <th class="col-label" *ngFor="let s of axisShort">
+              <div class="rot">{{ s }}</div>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let row of matrix; let i = index">
+            <th class="row-label">{{ axisShort[i] }}</th>
+            <td *ngFor="let cell of row" class="cell">
+              <span class="dot"
+                    *ngIf="cellHasDot(cell.rating)"
+                    [style.background]="cellColor(cell.rating)"
+                    [class.bordered]="cellNeedsBorder(cell.rating)">
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- Pair list — the actionable view, below the matrix per user
+       request so the heat-map is above the fold. Tap a row to open
+       both URLs in new tabs. -->
   <section class="pairs" *ngIf="pairs.length">
     <h2>Top mixes (sorted by rating)</h2>
     <table class="pair-table">
@@ -62,38 +96,6 @@
         </tr>
       </tbody>
     </table>
-  </section>
-
-  <!-- Heat-map matrix. Both axes carry the same URL list (deduplicated,
-       sorted by per-URL mean rating descending). Empty cells = no mix
-       for that pair. Rated=0 = white circle with thin border. Otherwise
-       solid colored dot. -->
-  <section class="matrix" *ngIf="axisUrls.length">
-    <h2>Pair matrix</h2>
-    <div class="matrix-scroll">
-      <table class="matrix-table">
-        <thead>
-          <tr>
-            <th class="corner"></th>
-            <th class="col-label" *ngFor="let s of axisShort">
-              <div class="rot">{{ s }}</div>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr *ngFor="let row of matrix; let i = index">
-            <th class="row-label">{{ axisShort[i] }}</th>
-            <td *ngFor="let cell of row" class="cell">
-              <span class="dot"
-                    *ngIf="cellHasDot(cell.rating)"
-                    [style.background]="cellColor(cell.rating)"
-                    [class.bordered]="cellNeedsBorder(cell.rating)">
-              </span>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
   </section>
 
   <!-- Empty state. -->

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.scss
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.scss
@@ -163,11 +163,11 @@ $matrix-row-label-width: 96px;
 
 .matrix-table th,
 .matrix-table td {
-  // Cell border color intentionally kept at #f3f3f3 per user request.
-  // On the black background these light gray grid lines read as a faint
-  // graph paper backdrop — exactly the right amount of structure to make
-  // the colored dots pop without competing with them.
-  border: 1px solid #f3f3f3;
+  // No grid lines — the colored dots are sufficient to convey structure;
+  // the grid was visually noisy. The sticky row/column header borders
+  // (border-right on .row-label, border-bottom on .corner) stay so the
+  // labels are still visually separated from the cell area.
+  border: 0;
   // Hard cap so an overly long URL label can't push a cell wider.
   box-sizing: border-box;
 }


### PR DESCRIPTION
Two adjustments:

1. **Removed the per-cell border** (the \`#f3f3f3\` graph-paper grid). With the dark theme the colored dots stand alone clearly; the grid was visually noisy. The sticky row/column header borders stay so the labels still feel separated from the cell area.
2. **Matrix renders above the pair list now.** Matrix is above the fold; ranked list of top mixes follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)