### PR TITLE
matrix: QR-code button + popup for shareable session deep links

### DIFF
--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.html
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.html
@@ -36,7 +36,14 @@
        for that pair. Rated=0 = white circle with thin border. Otherwise
        solid colored dot. Rendered FIRST so it's above the fold. -->
   <section class="matrix" *ngIf="axisUrls.length">
-    <h2>Pair matrix</h2>
+    <h2 class="matrix-heading">
+      <span>Pair matrix</span>
+      <button class="qr-btn" type="button" (click)="openQr()"
+              aria-label="Show QR code for this session">
+        <ion-icon name="qr-code-outline"></ion-icon>
+        <span class="qr-btn-label">QR</span>
+      </button>
+    </h2>
     <div class="matrix-scroll">
       <table class="matrix-table">
         <thead>
@@ -107,5 +114,24 @@
 
   <div class="empty" *ngIf="!session && !loading">
     Enter a session name above to load its matrix.
+  </div>
+
+  <!--
+    QR-code modal. Rendered when qrOpen is true. Backdrop covers the
+    whole viewport at z-index above all matrix sticky cells; clicking
+    anywhere on the backdrop (outside the white box) dismisses. The
+    inner .qr-box stops click propagation so taps on the QR don't close.
+  -->
+  <div class="qr-backdrop" *ngIf="qrOpen" (click)="closeQr()">
+    <div class="qr-box" (click)="$event.stopPropagation()">
+      <div class="qr-header">
+        <span>Scan to open {{ session }}</span>
+        <button class="qr-close" type="button" (click)="closeQr()"
+                aria-label="Close QR code">×</button>
+      </div>
+      <img class="qr-img" [src]="qrImageUrl"
+           [attr.alt]="'QR code for ' + qrTargetUrl">
+      <div class="qr-url">{{ qrTargetUrl }}</div>
+    </div>
   </div>
 </ion-content>

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.scss
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.scss
@@ -63,6 +63,107 @@ section h2 {
   color: $text-primary;
 }
 
+// Matrix heading needs to lay the title and the QR button on the same
+// row — flex makes the button float to the right of the section title.
+.matrix-heading {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+// QR button next to the "Pair matrix" heading. Compact icon-plus-label
+// pill; same monochrome palette as the rest of the dark theme.
+.qr-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: $bg-elevated;
+  color: $text-primary;
+  border: 1px solid $border-subtle;
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  ion-icon {
+    font-size: 16px;
+    line-height: 1;
+  }
+}
+
+.qr-btn:hover {
+  background: lighten($bg-elevated, 6%);
+}
+
+.qr-btn-label {
+  letter-spacing: 0.5px;
+}
+
+// ---- QR modal ----
+//
+// Translucent backdrop covers the viewport; clicking it dismisses the
+// modal. Inner .qr-box sits centered with a white background so the
+// QR contrast is preserved no matter what color theme is around it.
+.qr-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.qr-box {
+  background: #fff;
+  color: #000;
+  border-radius: 8px;
+  padding: 16px;
+  max-width: 360px;
+  width: 100%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+}
+
+.qr-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  color: #333;
+}
+
+.qr-close {
+  background: transparent;
+  border: 0;
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  color: #555;
+  padding: 0 4px;
+}
+
+.qr-close:hover {
+  color: #000;
+}
+
+.qr-img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.qr-url {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: #555;
+  word-break: break-all;
+  text-align: center;
+}
+
 // ---- pair list ----
 .pair-table {
   width: 100%;

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
 import { ToastController } from '@ionic/angular';
 
@@ -85,19 +86,39 @@ export class MatrixPage implements OnInit {
   axisShort: string[] = [];
   matrix: MatrixCell[][] = [];
 
+  // QR-code modal state. Opens when the user taps the QR button next to
+  // the "Pair matrix" heading; renders a fullscreen-translucent overlay
+  // with a QR encoding the current page URL (including ?session=) so
+  // anyone scanning lands on the same view.
+  qrOpen: boolean = false;
+
   constructor(
     private http: HttpClient,
     private toastController: ToastController,
+    private route: ActivatedRoute,
+    private router: Router,
   ) {}
 
   ngOnInit() {
-    // Default the search field + the loaded session to whatever the home
-    // page is currently working with. If localStorage.account is unset
-    // we just render the empty state until the user types a session.
+    // Session-selection priority:
+    //   1. ?session=<name> in the URL (QR-deep-link / shareable URLs)
+    //   2. localStorage.account (last-used session from the home page)
+    //   3. nothing — render the "enter a session name" empty state.
+    const fromUrl = this.route.snapshot.queryParamMap.get('session');
     const stored = window.localStorage.getItem('account');
-    if (stored) {
-      this.searchTerm = stored;
-      this.session = stored;
+    const initial = (fromUrl || stored || '').trim();
+    if (initial) {
+      this.searchTerm = initial;
+      this.session = initial;
+      // Make sure the URL query param reflects the loaded session even
+      // when we fell back to localStorage, so the QR code below always
+      // encodes a self-contained deep link.
+      this.syncUrlParam(initial);
+      // Also persist back to localStorage so opening a deep link sets
+      // the home page's session too.
+      if (fromUrl) {
+        window.localStorage.setItem('account', initial);
+      }
       this.refresh();
     }
   }
@@ -114,7 +135,54 @@ export class MatrixPage implements OnInit {
     this.session = term;
     // Persist so reload + the home page agree on which session is active.
     window.localStorage.setItem('account', term);
+    // Keep the URL in sync so a refresh / share / QR scan reproduces this view.
+    this.syncUrlParam(term);
     this.refresh();
+  }
+
+  /** Update ?session=<name> in the address bar without re-routing. */
+  private syncUrlParam(session: string) {
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { session },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
+  }
+
+  // ---- QR-code popup ----
+
+  /** Open the QR modal. The QR encodes the current full URL so a phone
+   *  scanning it lands on this exact view (with the right session). */
+  openQr() {
+    if (!this.session) {
+      this.toast('Enter a session first');
+      return;
+    }
+    this.qrOpen = true;
+  }
+
+  /** Close the QR modal. Bound to the backdrop click and close button. */
+  closeQr() {
+    this.qrOpen = false;
+  }
+
+  /** The URL the QR encodes — current page with ?session=<name> regardless
+   *  of what's in the address bar right now (defensive against router
+   *  not having committed the syncUrlParam navigation yet). */
+  get qrTargetUrl(): string {
+    const origin = window.location.origin;
+    const path = '/matrix';
+    return `${origin}${path}?session=${encodeURIComponent(this.session)}`;
+  }
+
+  /** Image src for the QR. api.qrserver.com is a long-standing free QR
+   *  service; the URL we encode is short (~60 chars) and contains only
+   *  the session name as user-supplied data — same data already exposed
+   *  in /sessions/<name>/matrix responses, so no new privacy concern. */
+  get qrImageUrl(): string {
+    const data = encodeURIComponent(this.qrTargetUrl);
+    return `https://api.qrserver.com/v1/create-qr-code/?size=320x320&margin=12&data=${data}`;
   }
 
   refresh() {


### PR DESCRIPTION
New QR button sits next to the **Pair matrix** heading. Tap → popup with a QR encoding the current page URL (with \`?session=<name>\`) so anyone scanning lands on the same view.

## Plumbing

- \`matrix.page.ts\` now reads \`?session=\` from the URL first, then falls back to \`localStorage.account\`, then the empty state. Deep links work; QR-scanned URLs also write back to localStorage so the home page picks up the same session.
- Search bar submit calls \`router.navigate\` with \`{ queryParams: { session }, replaceUrl: true }\` — address bar stays in sync, so the QR always reflects the current view.
- \`qrTargetUrl\` getter builds the deep-link URL; \`qrImageUrl\` wraps it via \`api.qrserver.com\` (no new npm dep — public free QR service; the encoded URL contains only the session name, same data the matrix endpoint already exposes).

## UI

- \`<h2 class="matrix-heading">\` uses flex so the QR pill sits to the right of the title.
- \`.qr-backdrop\` / \`.qr-box\`: translucent overlay, white inner box for QR contrast, click-outside-to-dismiss + explicit X button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)