### PR TITLE
matrix: switch from /sessions/<name>/matrix to /mixes (cross-session search)

### DIFF
--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.html
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.html
@@ -1,37 +1,31 @@
 <ion-header>
   <ion-toolbar color="dark">
-    <ion-title>Matrix — {{ session || '(no session)' }}</ion-title>
+    <ion-title>
+      Matrix
+      <span class="subtitle" *ngIf="count">— {{ count }} mixes</span>
+    </ion-title>
   </ion-toolbar>
 </ion-header>
 
 <ion-content>
   <!--
-    Search bar. Same UX as home.page: type a session name, hit Enter, the
-    page reloads for that session. Persists to localStorage.account so the
-    selection sticks across reloads and matches the home-feed filter.
-  -->
-  <div class="search-row">
-    <ion-searchbar
-      [(ngModel)]="searchTerm"
-      (keyup)="onSearchKeyup($event)"
-      placeholder="Session name (e.g. Sun-May-24-26)"
-      show-clear-button="focus">
-    </ion-searchbar>
-  </div>
-
-  <!--
-    Title / artist filter. Independent from the session search above.
-    Empty = show everything. Non-empty = case-insensitive substring
-    against x_title, y_title, x_artist, y_artist. The Direct toggle
-    affects the matrix only (pair list is always wide).
+    Filter row. Both inputs are substring matches against the backend's
+    /mixes endpoint. They AND-combine — leave one empty to ignore that
+    dimension. Same shape will hold when we add BPM/genre/etc.: just
+    drop another input on this row.
   -->
   <div class="filter-row">
     <input class="filter-input"
            type="text"
-           [ngModel]="filter"
-           (ngModelChange)="onFilterInput($event)"
-           placeholder="Filter by title or artist…">
-    <label class="strict-toggle" title="Show only mixes where BOTH endpoints match the filter">
+           [ngModel]="sessionFilter"
+           (ngModelChange)="onSessionInput($event)"
+           placeholder="Session (substring, e.g. Sun-May)">
+    <input class="filter-input"
+           type="text"
+           [ngModel]="q"
+           (ngModelChange)="onQInput($event)"
+           placeholder="Title or artist (substring)">
+    <label class="strict-toggle" title="Matrix: only show mixes where BOTH endpoints match the title/artist filter">
       <input type="checkbox"
              [checked]="strict"
              (change)="onStrictToggle($any($event.target).checked)">
@@ -39,27 +33,20 @@
     </label>
   </div>
 
-  <!-- Stats / loading / error banner -->
-  <div class="status-line" *ngIf="loading || errorMessage || stats">
+  <div class="status-line" *ngIf="loading || errorMessage || count">
     <span *ngIf="loading">Loading…</span>
     <span *ngIf="errorMessage" class="error">Error: {{ errorMessage }}</span>
-    <span *ngIf="stats && !loading && !errorMessage">
-      {{ stats.rated_with_urls }} rated mixes with URLs &middot;
-      {{ stats.rated_missing_urls }} missing URLs &middot;
-      {{ stats.extraction_pending }} pending extraction &middot;
-      {{ stats.total }} total videos in session
+    <span *ngIf="count && !loading && !errorMessage">
+      {{ count }} mix<ng-container *ngIf="count !== 1">es</ng-container>
+      <ng-container *ngIf="accountNumber"> &middot; account {{ accountNumber }}</ng-container>
     </span>
   </div>
 
-  <!-- Heat-map matrix. Both axes carry the same URL list (deduplicated,
-       sorted by per-URL mean rating descending). Empty cells = no mix
-       for that pair. Rated=0 = white circle with thin border. Otherwise
-       solid colored dot. Rendered FIRST so it's above the fold. -->
   <section class="matrix" *ngIf="axisUrls.length">
     <h2 class="matrix-heading">
       <span>Pair matrix</span>
       <button class="qr-btn" type="button" (click)="openQr()"
-              aria-label="Show QR code for this session">
+              aria-label="Show QR code for this search">
         <ion-icon name="qr-code-outline"></ion-icon>
         <span class="qr-btn-label">QR</span>
       </button>
@@ -91,9 +78,6 @@
     </div>
   </section>
 
-  <!-- Pair list — the actionable view, below the matrix per user
-       request so the heat-map is above the fold. Tap a row to open
-       both URLs in new tabs. -->
   <section class="pairs" *ngIf="pairs.length">
     <h2>Top mixes ({{ pairs.length }} shown, sorted by rating)</h2>
     <table class="pair-table">
@@ -102,6 +86,7 @@
           <th class="col-rating">Rating</th>
           <th class="col-mix">A</th>
           <th class="col-mix">B</th>
+          <th class="col-session">Session</th>
           <th class="col-file">File</th>
         </tr>
       </thead>
@@ -124,33 +109,28 @@
             <div class="mix-title" *ngIf="p.yTitle" [attr.title]="p.yTitle">{{ p.yTitle }}</div>
             <a class="mix-url" (click)="openUrl(p.yUrl)">{{ p.yShort }}</a>
           </td>
+          <td class="col-session">{{ p.session }}</td>
           <td class="col-file">{{ p.filename }}</td>
         </tr>
       </tbody>
     </table>
   </section>
 
-  <!-- Empty state. -->
-  <div class="empty" *ngIf="!loading && !errorMessage && session && !pairs.length">
-    No rated mixes with extracted pair URLs found for
-    <strong>{{ session }}</strong>. Rate some videos on the home page; the
-    matrix will populate as URLs are extracted.
+  <!-- Empty / setup states. -->
+  <div class="empty" *ngIf="!loading && !errorMessage && accountNumber && !pairs.length">
+    No rated mixes match the current filters.
   </div>
 
-  <div class="empty" *ngIf="!session && !loading">
-    Enter a session name above to load its matrix.
+  <div class="empty" *ngIf="!accountNumber && !loading">
+    No account set. Visit the home page to choose a session, or open
+    /matrix?account=&lt;your-session&gt; to load directly.
   </div>
 
-  <!--
-    QR-code modal. Rendered when qrOpen is true. Backdrop covers the
-    whole viewport at z-index above all matrix sticky cells; clicking
-    anywhere on the backdrop (outside the white box) dismisses. The
-    inner .qr-box stops click propagation so taps on the QR don't close.
-  -->
+  <!-- QR-code modal. -->
   <div class="qr-backdrop" *ngIf="qrOpen" (click)="closeQr()">
     <div class="qr-box" (click)="$event.stopPropagation()">
       <div class="qr-header">
-        <span>Scan to open {{ session }}</span>
+        <span>Scan to open this view</span>
         <button class="qr-close" type="button" (click)="closeQr()"
                 aria-label="Close QR code">×</button>
       </div>

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.scss
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.scss
@@ -273,11 +273,29 @@ section h2 {
   text-decoration: underline;
 }
 
+// Session column on the pair list — narrow text, secondary color so
+// it reads as metadata next to the dominant A/B mix cells.
+.col-session {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: $text-secondary;
+  font-size: 11px;
+  vertical-align: top !important;
+  white-space: nowrap;
+}
+
 .col-file {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   color: $text-muted;
   font-size: 11px;
   vertical-align: top !important;
+}
+
+// Optional smaller subtitle in the page header.
+.subtitle {
+  font-weight: 400;
+  opacity: 0.7;
+  margin-left: 8px;
+  font-size: 0.85em;
 }
 
 // ---- rating dots (shared by pair list + matrix) ----

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.ts
@@ -1,36 +1,28 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { ToastController } from '@ionic/angular';
 
 /**
- * MatrixPage — visualises the user's ratings for a session as:
+ * MatrixPage — search-driven view over the user's rated mixes.
  *
- *   1. A ranked list of pairs (best mixes at the top), and
- *   2. An NxN heat-map matrix indexed by the source YouTube URLs.
+ * All filters (session, title/artist, future: BPM, genre, ...) are
+ * AND-combined and sent to the backend's /mixes endpoint. The matrix
+ * + pair list always render from the unified result set, so a query
+ * like q=Chronixx spans every session the user has touched.
  *
- * Backend feed: `GET /sessions/<name>/matrix?account_number=<x>`. Returns
- * each video in the session with its rating + extracted (x_url, y_url)
- * pair URLs and (x_title, y_title, x_artist, y_artist) song metadata.
- * Videos that haven't been rated, or that have no extracted URLs
- * (extraction failed / no `network` tag in the mp4), are silently
- * skipped — the page is for actionable show-curation, not a complete
- * audit of the session.
- *
- * URL params:
- *   ?session=<name>  loads/persists which session is being viewed
- *   ?filter=<text>   case-insensitive substring filter on titles/artists
- *   ?strict=1        matrix shows only mixes where BOTH endpoints match
- *                    the filter (rather than the wider "anything paired
- *                    with a matched URL" default)
- *
- * The pair-list filter is always "wide" — a row is shown if filter
- * matches any of the four metadata fields. The strict toggle only
- * affects the matrix.
+ * URL params (all optional, persisted across reload + QR):
+ *   ?session=<text>  case-insensitive substring on videos.session
+ *   ?q=<text>        case-insensitive substring on title/artist
+ *   ?strict=1        matrix shows only mixes where BOTH endpoints match q
+ *                    (pair list is always "wide")
+ *   ?account=<text>  override the user identity (defaults to
+ *                    localStorage.account, the home page's session name)
  */
 
 interface MatrixVideo {
   id: number;
+  session: string;
   url: string;
   filename: string;
   x_url: string | null;
@@ -39,28 +31,19 @@ interface MatrixVideo {
   y_title: string | null;
   x_artist: string | null;
   y_artist: string | null;
-  metadata_extracted_at: string | null;
   rating: number | null;
 }
 
-interface MatrixStats {
-  total: number;
-  rated: number;
-  rated_with_urls: number;
-  rated_missing_urls: number;
-  extraction_pending: number;
-}
-
-interface MatrixResponse {
-  session: string;
-  account_number: string;
+interface MixesResponse {
   videos: MatrixVideo[];
-  stats: MatrixStats;
+  count: number;
+  filters: { account_number: string; session: string | null; q: string | null };
 }
 
 interface PairRow {
   videoId: number;
   filename: string;
+  session: string;
   xUrl: string;
   yUrl: string;
   xShort: string;
@@ -83,50 +66,35 @@ interface MatrixCell {
   styleUrls: ['./matrix.page.scss'],
 })
 export class MatrixPage implements OnInit, OnDestroy {
-  session: string = '';
-  searchTerm: string = '';
-  loading: boolean = false;
-  errorMessage: string = '';
-  stats: MatrixStats | null = null;
-
-  // Title/artist filter state. Both persisted to URL params so a QR /
-  // shared link reproduces the exact view. filter is case-insensitive
-  // substring; strict toggles matrix display between "matched cells
-  // only" and "matched cells + their 1-hop neighborhood".
-  filter: string = '';
+  // Filters bound to inputs at the top of the page. Every change calls
+  // refresh() (which talks to /mixes). Same shape will hold when we add
+  // BPM/genre/tempo etc. later.
+  sessionFilter: string = '';
+  q: string = '';
   strict: boolean = false;
 
-  // Raw response from /sessions/<name>/matrix. Kept so that filter
-  // changes can rebuild pairs+matrix locally without re-fetching.
+  // User identity. Defaults to localStorage.account (the home page's
+  // current session) but can be overridden via ?account= in the URL.
+  accountNumber: string = '';
+
+  loading: boolean = false;
+  errorMessage: string = '';
+  count: number = 0;
+
+  // Raw response from /mixes, kept so the strict toggle can rebuild the
+  // matrix locally without re-fetching.
   private rawVideos: MatrixVideo[] = [];
 
-  // The actionable view: every (x, y, rating) where both URLs are present
-  // and the user rated it, sorted by rating descending. Already filtered.
   pairs: PairRow[] = [];
 
-  // The matrix view. axisUrls is the ordered list of unique source URLs
-  // (both axes share the same ordering — the relation is symmetric).
-  // axisShort is the truncated label shown on the axis. axisTooltip is
-  // the artist+title shown on hover. matrix[i][j] is the cell for
-  // (axisUrls[i], axisUrls[j]). All three respect the current filter.
   axisUrls: string[] = [];
   axisShort: string[] = [];
   axisTooltip: string[] = [];
   matrix: MatrixCell[][] = [];
 
-  // QR-code modal state. Opens when the user taps the QR button next to
-  // the "Pair matrix" heading; renders a fullscreen-translucent overlay
-  // with a QR encoding the current page URL (including ?session=) so
-  // anyone scanning lands on the same view.
   qrOpen: boolean = false;
 
-  // setInterval handle for the 5-minute auto-refresh. Cleared in
-  // ngOnDestroy so navigating away doesn't leak the timer.
   private autoRefreshHandle: any = null;
-
-  // 5 minutes between automatic refreshes. Long enough that we're not
-  // hammering the backend; short enough that ratings done on a phone
-  // show up on a wall-mounted matrix view without manual reload.
   private readonly AUTO_REFRESH_MS = 5 * 60 * 1000;
 
   constructor(
@@ -137,40 +105,30 @@ export class MatrixPage implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    // Session-selection priority:
-    //   1. ?session=<name> in the URL (QR-deep-link / shareable URLs)
-    //   2. localStorage.account (last-used session from the home page)
-    //   3. nothing — render the "enter a session name" empty state.
     const qp = this.route.snapshot.queryParamMap;
-    const fromUrl = qp.get('session');
-    const stored = window.localStorage.getItem('account');
-    const initial = (fromUrl || stored || '').trim();
-
-    // Filter + strict come straight from URL — no localStorage. People
-    // expect filters to reset on a fresh visit, but persist within a
-    // URL they shared/scanned.
-    this.filter = (qp.get('filter') || '').trim();
+    this.sessionFilter = (qp.get('session') || '').trim();
+    this.q = (qp.get('q') || '').trim();
     this.strict = qp.get('strict') === '1';
 
-    if (initial) {
-      this.searchTerm = initial;
-      this.session = initial;
-      // Sync ALL the params we care about so the QR + reload reproduce
-      // exactly. Includes session, filter, strict.
-      this.syncUrlParams();
-      // Also persist back to localStorage so opening a deep link sets
-      // the home page's session too.
-      if (fromUrl) {
-        window.localStorage.setItem('account', initial);
-      }
+    // Account identity. Honor ?account= override first, otherwise fall
+    // back to localStorage. If neither, render the "set an account"
+    // empty state.
+    const fromUrl = (qp.get('account') || '').trim();
+    const stored = (window.localStorage.getItem('account') || '').trim();
+    this.accountNumber = fromUrl || stored;
+    if (fromUrl) {
+      window.localStorage.setItem('account', fromUrl);
+    }
+
+    // Sync URL so QR + reload reproduce the current view exactly.
+    this.syncUrlParams();
+
+    if (this.accountNumber) {
       this.refresh();
     }
 
-    // Auto-refresh fires regardless of whether we had an initial session
-    // — once the user types one in the search bar, the tick that comes
-    // ~5 minutes later will pick it up via this.session being non-empty.
     this.autoRefreshHandle = setInterval(() => {
-      if (this.session && !this.loading) {
+      if (this.accountNumber && !this.loading) {
         console.log('matrix.page: auto-refresh tick');
         this.refresh();
       }
@@ -184,47 +142,36 @@ export class MatrixPage implements OnInit, OnDestroy {
     }
   }
 
-  /** Submit handler for the session searchbar. Reloads for the typed session. */
-  onSearchKeyup(event: KeyboardEvent) {
-    if (event.key !== 'Enter' && event.key !== 'Return') {
-      return;
-    }
-    const term = ((event.target as HTMLInputElement).value || '').trim();
-    if (!term) {
-      return;
-    }
-    this.session = term;
-    // Persist so reload + the home page agree on which session is active.
-    window.localStorage.setItem('account', term);
-    // Keep the URL in sync so a refresh / share / QR scan reproduces this view.
+  onSessionInput(value: string) {
+    this.sessionFilter = (value || '').trim();
     this.syncUrlParams();
     this.refresh();
   }
 
-  /** Called on every keystroke in the title/artist filter input. Cheap —
-   *  rebuilds pairs + matrix locally from rawVideos, no server round-trip. */
-  onFilterInput(value: string) {
-    this.filter = (value || '').trim();
+  onQInput(value: string) {
+    this.q = (value || '').trim();
     this.syncUrlParams();
-    this.applyFilter();
+    this.refresh();
   }
 
-  /** Toggle handler for the Direct/Wide matrix mode switch. */
+  /** Strict is client-side only — affects matrix rendering, not the
+   *  backend query (which already returned the filtered set). */
   onStrictToggle(value: boolean) {
     this.strict = !!value;
     this.syncUrlParams();
-    this.applyFilter();
+    this.applyStrict();
   }
 
-  /** Update ?session=<name>&filter=<f>&strict=1 in the address bar
-   *  without re-routing. Omits empty values so the URL stays tidy. */
+  /** Update ?session=&q=&strict= in the address bar without re-routing.
+   *  Omits empty values so the URL stays tidy. */
   private syncUrlParams() {
-    const queryParams: any = { session: this.session || null };
-    queryParams.filter = this.filter ? this.filter : null;
-    queryParams.strict = this.strict ? '1' : null;
     this.router.navigate([], {
       relativeTo: this.route,
-      queryParams,
+      queryParams: {
+        session: this.sessionFilter || null,
+        q: this.q || null,
+        strict: this.strict ? '1' : null,
+      },
       queryParamsHandling: 'merge',
       replaceUrl: true,
     });
@@ -232,62 +179,60 @@ export class MatrixPage implements OnInit, OnDestroy {
 
   // ---- QR-code popup ----
 
-  /** Open the QR modal. The QR encodes the current full URL so a phone
-   *  scanning it lands on this exact view (with the right session). */
   openQr() {
-    if (!this.session) {
-      this.toast('Enter a session first');
+    if (!this.accountNumber) {
+      this.toast('Set an account first');
       return;
     }
     this.qrOpen = true;
   }
 
-  /** Close the QR modal. Bound to the backdrop click and close button. */
   closeQr() {
     this.qrOpen = false;
   }
 
-  /** The URL the QR encodes — current page with session + filter + strict
-   *  baked in so the scanner lands on the same view. */
+  /** Deep-link URL the QR encodes — current filters preserved exactly. */
   get qrTargetUrl(): string {
     const origin = window.location.origin;
-    const path = '/matrix';
     const params = new URLSearchParams();
-    params.set('session', this.session);
-    if (this.filter) params.set('filter', this.filter);
+    if (this.sessionFilter) params.set('session', this.sessionFilter);
+    if (this.q) params.set('q', this.q);
     if (this.strict) params.set('strict', '1');
-    return `${origin}${path}?${params.toString()}`;
+    // Always include account in the QR — the recipient may not have it
+    // in their localStorage.
+    if (this.accountNumber) params.set('account', this.accountNumber);
+    const qs = params.toString();
+    return `${origin}/matrix${qs ? '?' + qs : ''}`;
   }
 
-  /** Image src for the QR. api.qrserver.com is a long-standing free QR
-   *  service; the URL we encode is short (~80 chars) and contains only
-   *  the session name + user-typed filter — no PII. */
   get qrImageUrl(): string {
     const data = encodeURIComponent(this.qrTargetUrl);
     return `https://api.qrserver.com/v1/create-qr-code/?size=320x320&margin=12&data=${data}`;
   }
 
   refresh() {
-    if (!this.session) {
+    if (!this.accountNumber) {
       return;
     }
     this.loading = true;
     this.errorMessage = '';
-    const url =
-      `/sessions/${encodeURIComponent(this.session)}/matrix` +
-      `?account_number=${encodeURIComponent(this.session)}`;
-    this.http.get<MatrixResponse>(url).subscribe(
+    let params = new HttpParams().set('account_number', this.accountNumber);
+    if (this.sessionFilter) params = params.set('session', this.sessionFilter);
+    if (this.q) params = params.set('q', this.q);
+
+    this.http.get<MixesResponse>('/mixes', { params }).subscribe(
       (resp) => {
-        this.stats = resp.stats;
         this.rawVideos = resp.videos;
-        this.applyFilter();
+        this.count = resp.count;
+        this.applyStrict();
         this.loading = false;
       },
       (err) => {
         console.error('matrix.page: load failed', err);
         this.errorMessage =
-          (err && err.error && err.error.error) || 'failed to load matrix';
+          (err && err.error && err.error.error) || 'failed to load mixes';
         this.rawVideos = [];
+        this.count = 0;
         this.pairs = [];
         this.axisUrls = [];
         this.axisShort = [];
@@ -298,40 +243,16 @@ export class MatrixPage implements OnInit, OnDestroy {
     );
   }
 
-  /**
-   * Rebuild pairs + matrix from rawVideos, applying the current
-   * filter + strict state. Called after fetch and on every filter/
-   * toggle keystroke.
-   */
-  private applyFilter() {
-    // 1. Actionable subset (rated + URLs present). Same as before.
-    const actionable = this.rawVideos.filter(
-      (v) =>
-        v.rating !== null &&
-        typeof v.x_url === 'string' &&
-        typeof v.y_url === 'string' &&
-        v.x_url &&
-        v.y_url,
-    );
+  /** Rebuild pairs + matrix from rawVideos. Strict mode only affects
+   *  the matrix — pair list always shows every backend-matched mix. */
+  private applyStrict() {
+    const actionable = this.rawVideos;
 
-    // 2. "Matching" predicate. Empty filter matches everything.
-    //    Otherwise: case-insensitive substring against any of the four
-    //    metadata fields.
-    const needle = this.filter.toLowerCase();
-    const matches = (v: MatrixVideo): boolean => {
-      if (!needle) return true;
-      return [v.x_title, v.y_title, v.x_artist, v.y_artist].some(
-        (s) => typeof s === 'string' && s.toLowerCase().includes(needle),
-      );
-    };
-
-    // 3. Pair list — always "wide": include any video where filter
-    //    matches any side. Sorted by rating desc.
     this.pairs = actionable
-      .filter(matches)
       .map((v) => ({
         videoId: v.id,
         filename: v.filename,
+        session: v.session,
         xUrl: v.x_url!,
         yUrl: v.y_url!,
         xShort: shortenYouTube(v.x_url!),
@@ -344,36 +265,12 @@ export class MatrixPage implements OnInit, OnDestroy {
       }))
       .sort((a, b) => b.rating - a.rating || a.videoId - b.videoId);
 
-    // 4. Matched-URL set: URLs participating in any matching video.
-    //    Used by both strict and wide modes.
     const matchedUrls = new Set<string>();
-    for (const v of actionable.filter(matches)) {
+    for (const v of actionable) {
       matchedUrls.add(v.x_url!);
       matchedUrls.add(v.y_url!);
     }
 
-    // 5. Axis URLs depend on the strict/wide mode:
-    //      strict: only matched URLs; cells fire only when both endpoints
-    //              are matched.
-    //      wide:   matched URLs + any URL ever paired with a matched URL
-    //              (1-hop neighborhood). Lets you see what your filtered
-    //              songs mix WITH, not just the cells where they match
-    //              each other.
-    let candidateUrls: Set<string>;
-    if (this.strict) {
-      candidateUrls = matchedUrls;
-    } else {
-      candidateUrls = new Set(matchedUrls);
-      for (const v of actionable) {
-        if (matchedUrls.has(v.x_url!) || matchedUrls.has(v.y_url!)) {
-          candidateUrls.add(v.x_url!);
-          candidateUrls.add(v.y_url!);
-        }
-      }
-    }
-
-    // 6. Per-URL artist/title for axis labels + tooltips. A URL appears
-    //    in many videos; we just take the first non-null we see.
     const urlMeta = new Map<string, { title: string | null; artist: string | null }>();
     for (const v of actionable) {
       for (const [u, t, a] of [
@@ -390,10 +287,8 @@ export class MatrixPage implements OnInit, OnDestroy {
       }
     }
 
-    // 7. Sort axis by per-URL mean rating descending so the hottest songs
-    //    cluster at the top-left.
     const meanByUrl = new Map<string, number>();
-    for (const u of candidateUrls) {
+    for (const u of matchedUrls) {
       const ratings: number[] = [];
       for (const v of actionable) {
         if (v.x_url === u || v.y_url === u) ratings.push(v.rating!);
@@ -403,7 +298,7 @@ export class MatrixPage implements OnInit, OnDestroy {
         ratings.reduce((a, b) => a + b, 0) / Math.max(1, ratings.length),
       );
     }
-    const sortedAxis = Array.from(candidateUrls).sort(
+    const sortedAxis = Array.from(matchedUrls).sort(
       (a, b) => meanByUrl.get(b)! - meanByUrl.get(a)!,
     );
 
@@ -418,7 +313,6 @@ export class MatrixPage implements OnInit, OnDestroy {
       return parts.length ? parts.join(' — ') : u;
     });
 
-    // 8. Empty NxN matrix.
     const n = sortedAxis.length;
     const cells: MatrixCell[][] = [];
     for (let i = 0; i < n; i++) {
@@ -429,19 +323,29 @@ export class MatrixPage implements OnInit, OnDestroy {
       cells.push(row);
     }
 
-    // 9. Place each video. Symmetric (a mix of A+B is the same as B+A).
-    //    Cells are kept only if both endpoints are in candidateUrls;
-    //    strict additionally requires both endpoints in matchedUrls so
-    //    we don't fill cells where only one side matches the filter.
+    // Strict mode (only meaningful when q is set): only fill a cell if
+    // BOTH endpoints' titles or artists themselves match q. Otherwise
+    // a Chronixx × Kelis mix shows under q="Kelis" because Kelis
+    // appears, even though Chronixx doesn't match. Strict hides that
+    // and shows only mixes where both songs match the filter.
+    const needle = this.q.toLowerCase();
+    const urlMatchesQ = (u: string): boolean => {
+      if (!needle) return true;
+      const m = urlMeta.get(u);
+      if (!m) return false;
+      return [m.title, m.artist].some(
+        (s) => typeof s === 'string' && s.toLowerCase().includes(needle),
+      );
+    };
+
     const idx = new Map<string, number>();
     sortedAxis.forEach((u, i) => idx.set(u, i));
     for (const v of actionable) {
       const i = idx.get(v.x_url!);
       const j = idx.get(v.y_url!);
       if (i === undefined || j === undefined) continue;
-      if (this.strict) {
-        // Both endpoints must match the filter — keeps strict view honest.
-        if (!matchedUrls.has(v.x_url!) || !matchedUrls.has(v.y_url!)) continue;
+      if (this.strict && needle) {
+        if (!urlMatchesQ(v.x_url!) || !urlMatchesQ(v.y_url!)) continue;
       }
       for (const [a, b] of [[i, j], [j, i]] as [number, number][]) {
         const cell = cells[a][b];
@@ -454,20 +358,17 @@ export class MatrixPage implements OnInit, OnDestroy {
     this.matrix = cells;
   }
 
-  /** Color spec from the user's design: 0..5 + null. */
   cellColor(rating: number | null): string {
-    if (rating === null) return 'transparent';  // no mix at this cell
-    if (rating === 0) return '#ffffff';          // skipped — white circle, thin border
-    if (rating === 1) return '#1565c0';          // blue
-    if (rating === 2) return '#42a5f5';          // light blue
-    if (rating === 3) return '#fb8c00';          // orange
-    if (rating === 4) return '#fdd835';          // yellow
-    if (rating === 5) return '#e53935';          // red
+    if (rating === null) return 'transparent';
+    if (rating === 0) return '#ffffff';
+    if (rating === 1) return '#1565c0';
+    if (rating === 2) return '#42a5f5';
+    if (rating === 3) return '#fb8c00';
+    if (rating === 4) return '#fdd835';
+    if (rating === 5) return '#e53935';
     return 'transparent';
   }
 
-  /** Empty cells (no mix) render as nothing; rated=0 still gets a white
-   *  circle with a thin border. Anything else is a solid colored disc. */
   cellNeedsBorder(rating: number | null): boolean {
     return rating === 0;
   }
@@ -476,13 +377,10 @@ export class MatrixPage implements OnInit, OnDestroy {
     return rating !== null;
   }
 
-  /** Used by the pair-list rating badge — same colors as cellColor but
-   *  with white default so the badge always renders something. */
   ratingColor(rating: number): string {
     return this.cellColor(rating);
   }
 
-  /** Toast helper for action feedback (copy-url, etc.) */
   async toast(message: string) {
     const t = await this.toastController.create({
       message,
@@ -492,26 +390,17 @@ export class MatrixPage implements OnInit, OnDestroy {
     t.present();
   }
 
-  /** Trivially "open the URL in a new tab" for pair-list clicks. */
   openUrl(url: string) {
     window.open(url, '_blank', 'noopener,noreferrer');
   }
 }
 
 
-/**
- * Best-effort URL shortener for YouTube links. Returns the 11-char video
- * id when we can extract one (the part after `v=` or after `youtu.be/`),
- * else the last 11 chars of the URL. Keeps axis labels narrow.
- */
 function shortenYouTube(url: string): string {
   if (!url) return '';
-  // youtu.be/<id>?optional-query
   const shortMatch = url.match(/youtu\.be\/([A-Za-z0-9_-]{11})/);
   if (shortMatch) return shortMatch[1];
-  // youtube.com/watch?v=<id>
   const longMatch = url.match(/[?&]v=([A-Za-z0-9_-]{11})/);
   if (longMatch) return longMatch[1];
-  // Fallback: last 11 chars (matches the YouTube id length).
   return url.slice(-11);
 }


### PR DESCRIPTION
Decouples the page from session-as-path. Session is now just another search input alongside title/artist; both are substring filters sent to the new \`/mixes\` endpoint ([music-k8s #40](https://github.com/nospaceleftondevice/music-k8s/pull/40), already deployed). Cross-session queries like \`q=Chronixx\` with session empty now work.

## Layout

- Filter row has **two equal text inputs** (Session + Title/Artist) and the Direct toggle. Same shape extends cleanly to BPM/genre/tempo when those land.
- Pair list grows a **Session column** (always visible).
- Page title shows the result count.
- Empty state copy updated.

## URL params

| param | semantics |
|---|---|
| \`session\` | substring on \`videos.session\` (was path component) |
| \`q\` | substring on title/artist |
| \`strict\` | matrix-only client-side strict mode |
| \`account\` | new — override accountNumber for QR shares |

QR encodes all four.

## Strict semantics

Now genuinely meaningful: when \`q\` is set, strict hides cells where only one endpoint matches. Otherwise a Chronixx × Kelis mix shows under \`q=Kelis\` via Kelis, even though Chronixx doesn't match. With strict on, only mixes where BOTH songs match appear. No-op when \`q\` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)