### PR TITLE
matrix: per-field AND/OR mode pill next to Title/Artist input

### DIFF
--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.html
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.html
@@ -15,16 +15,40 @@
     drop another input on this row.
   -->
   <div class="filter-row">
+    <!--
+      Session input. No AND/OR toggle — session is always a narrowing
+      constraint (typing a session always means "only this session").
+    -->
     <input class="filter-input"
            type="text"
            [ngModel]="sessionFilter"
            (ngModelChange)="onSessionInput($event)"
            placeholder="Session (substring, e.g. Sun-May)">
-    <input class="filter-input"
-           type="text"
-           [ngModel]="q"
-           (ngModelChange)="onQInput($event)"
-           placeholder="Title or artist (substring)">
+
+    <!--
+      Title/artist input + AND/OR mode pill. AND (default) = filter must
+      match. OR = result needs to match this OR any other OR filter
+      (useful once BPM/key dimensions land). The pill is disabled+greyed
+      when the input is empty.
+    -->
+    <div class="filter-with-mode">
+      <input class="filter-input"
+             type="text"
+             [ngModel]="q"
+             (ngModelChange)="onQInput($event)"
+             placeholder="Title or artist (substring)">
+      <button class="mode-pill"
+              type="button"
+              [class.is-or]="qMode === 'or'"
+              [disabled]="!q"
+              (click)="onQModeToggle()"
+              [attr.title]="qMode === 'and'
+                ? 'Currently AND: must match. Click to switch to OR.'
+                : 'Currently OR: at least one OR filter must match. Click to switch to AND.'">
+        {{ qMode === 'or' ? 'OR' : 'AND' }}
+      </button>
+    </div>
+
     <label class="strict-toggle" title="Matrix: only show mixes where BOTH endpoints match the title/artist filter">
       <input type="checkbox"
              [checked]="strict"

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.scss
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.scss
@@ -62,6 +62,53 @@ ion-content {
   color: $text-muted;
 }
 
+// Wraps a filter input + its AND/OR mode pill. Flex with no gap so the
+// pill butts against the right edge of the input (visually paired).
+.filter-with-mode {
+  display: flex;
+  align-items: stretch;
+  flex: 1;
+  min-width: 0;
+}
+
+.filter-with-mode .filter-input {
+  flex: 1;
+  // Square off the right edge so the pill sits flush.
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right: 0;
+}
+
+.mode-pill {
+  // Compact AND/OR toggle. Visually attached to the filter input on its
+  // right. Default state (AND) looks neutral; OR state lights up blue
+  // so it's obvious when the user has switched to broaden semantics.
+  background: $bg-elevated;
+  color: $text-secondary;
+  border: 1px solid $border-subtle;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
+  padding: 0 10px;
+  min-width: 48px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+}
+
+.mode-pill.is-or {
+  background: $link;
+  color: #fff;
+  border-color: $link;
+}
+
+.mode-pill:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .strict-toggle {
   display: inline-flex;
   align-items: center;

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.ts
@@ -71,6 +71,11 @@ export class MatrixPage implements OnInit, OnDestroy {
   // BPM/genre/tempo etc. later.
   sessionFilter: string = '';
   q: string = '';
+  // Per-filter mode: 'and' = must match (narrows), 'or' = at least one
+  // OR filter must match (broadens). Default 'and'. Session has no mode
+  // toggle — it's always a narrowing constraint. Same shape extends to
+  // future BPM/key/genre inputs (each gets its own *Mode field).
+  qMode: 'and' | 'or' = 'and';
   strict: boolean = false;
 
   // User identity. Defaults to localStorage.account (the home page's
@@ -108,6 +113,8 @@ export class MatrixPage implements OnInit, OnDestroy {
     const qp = this.route.snapshot.queryParamMap;
     this.sessionFilter = (qp.get('session') || '').trim();
     this.q = (qp.get('q') || '').trim();
+    // q_mode comes from URL too. Whitelist to {'and','or'}.
+    this.qMode = qp.get('q_mode') === 'or' ? 'or' : 'and';
     this.strict = qp.get('strict') === '1';
 
     // Account identity. Honor ?account= override first, otherwise fall
@@ -154,6 +161,16 @@ export class MatrixPage implements OnInit, OnDestroy {
     this.refresh();
   }
 
+  /** Flip q's AND/OR mode. Triggers a refetch since the WHERE clause
+   *  composition depends on it. No-op when q is empty (nothing to mode). */
+  onQModeToggle() {
+    this.qMode = this.qMode === 'and' ? 'or' : 'and';
+    this.syncUrlParams();
+    if (this.q) {
+      this.refresh();
+    }
+  }
+
   /** Strict is client-side only — affects matrix rendering, not the
    *  backend query (which already returned the filtered set). */
   onStrictToggle(value: boolean) {
@@ -162,14 +179,17 @@ export class MatrixPage implements OnInit, OnDestroy {
     this.applyStrict();
   }
 
-  /** Update ?session=&q=&strict= in the address bar without re-routing.
-   *  Omits empty values so the URL stays tidy. */
+  /** Update ?session=&q=&q_mode=&strict= in the address bar without
+   *  re-routing. Omits empty values + default modes so the URL stays tidy. */
   private syncUrlParams() {
     this.router.navigate([], {
       relativeTo: this.route,
       queryParams: {
         session: this.sessionFilter || null,
         q: this.q || null,
+        // Only encode q_mode when non-default AND q is actually set,
+        // so plain searches don't pollute the URL with ?q_mode=and.
+        q_mode: (this.q && this.qMode === 'or') ? 'or' : null,
         strict: this.strict ? '1' : null,
       },
       queryParamsHandling: 'merge',
@@ -196,7 +216,10 @@ export class MatrixPage implements OnInit, OnDestroy {
     const origin = window.location.origin;
     const params = new URLSearchParams();
     if (this.sessionFilter) params.set('session', this.sessionFilter);
-    if (this.q) params.set('q', this.q);
+    if (this.q) {
+      params.set('q', this.q);
+      if (this.qMode === 'or') params.set('q_mode', 'or');
+    }
     if (this.strict) params.set('strict', '1');
     // Always include account in the QR — the recipient may not have it
     // in their localStorage.
@@ -218,7 +241,11 @@ export class MatrixPage implements OnInit, OnDestroy {
     this.errorMessage = '';
     let params = new HttpParams().set('account_number', this.accountNumber);
     if (this.sessionFilter) params = params.set('session', this.sessionFilter);
-    if (this.q) params = params.set('q', this.q);
+    if (this.q) {
+      params = params.set('q', this.q);
+      // Only pass q_mode when non-default. Backend defaults to 'and'.
+      if (this.qMode === 'or') params = params.set('q_mode', 'or');
+    }
 
     this.http.get<MixesResponse>('/mixes', { params }).subscribe(
       (resp) => {


### PR DESCRIPTION
Pairs with [music-k8s #45](https://github.com/nospaceleftondevice/music-k8s/pull/45) (already deployed).

- Title/Artist input gets a small **AND/OR pill** flush against its right edge. Default AND is neutral grey; OR lights up blue so it's visually clear when search is broadened.
- Disabled+greyed when q is empty (nothing to mode).
- \`?q_mode=or\` persists in URL when q is set AND mode is OR. Default never pollutes URL.
- QR encodes \`q_mode\` so shared link reproduces choice.
- **Session has no mode toggle** — it's always a narrowing constraint per your spec.

Shape extends cleanly to BPM/key/genre — each gets its own \`.filter-with-mode\` wrapper + \`*Mode\` field + \`*_mode\` URL param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)