### PR TITLE
matrix + home: work without account; prompt-OK empty redirects

### DIFF
--- a/vendor/github.com/eaabak/ionTok/src/app/pages/home/home.page.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/home/home.page.ts
@@ -546,12 +546,15 @@ export class HomePage implements OnInit {
         // prompt() returns null when the user cancels and '' for empty
         // input. Either case used to be stored literally, which then
         // propagated to the backend as session=null. Guard so we only
-        // store a non-empty trimmed string; if the user cancels, leave
-        // 'account' unset and data.service.getVideoList will return an
-        // empty list (see its session guard).
+        // store a non-empty trimmed string; if the user cancels or
+        // submits empty, treat it as "I don't have a session" and
+        // redirect to /matrix where the user can browse the library.
         const entered = (prompt("Enter show name") || '').trim();
         if (entered) {
           window.sessionStorage.setItem('account', entered);
+        } else {
+          this.router.navigateByUrl('/matrix');
+          return;
         }
       }
       const acct = window.sessionStorage.getItem('account');

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.html
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.html
@@ -146,13 +146,19 @@
   </section>
 
   <!-- Empty / setup states. -->
-  <div class="empty" *ngIf="!loading && !errorMessage && accountNumber && !pairs.length">
-    No rated mixes match the current filters.
+  <div class="empty" *ngIf="!loading && !errorMessage && !pairs.length && (sessionFilter || q)">
+    No matches for the current filters.
   </div>
 
-  <div class="empty" *ngIf="!accountNumber && !loading">
-    No account set. Visit the home page to choose a session, or open
-    /matrix?account=&lt;your-session&gt; to load directly.
+  <div class="empty" *ngIf="!loading && !errorMessage && !pairs.length && !sessionFilter && !q">
+    <ng-container *ngIf="accountNumber">
+      Type a session, title, or artist above to search.
+    </ng-container>
+    <ng-container *ngIf="!accountNumber">
+      No account set — only library results are available.<br>
+      Type a session, title, or artist above to search the library,
+      or visit the home page to choose a session.
+    </ng-container>
   </div>
 
   <!-- QR-code modal. -->

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.ts
@@ -146,12 +146,13 @@ export class MatrixPage implements OnInit, OnDestroy {
     // Sync URL so QR + reload reproduce the current view exactly.
     this.syncUrlParams();
 
-    if (this.accountNumber) {
-      this.refresh();
-    }
+    // refresh() works without an account now — it'll return only
+    // library results in that case (so the user can browse the seed
+    // even before loading a session). Always fire on init.
+    this.refresh();
 
     this.autoRefreshHandle = setInterval(() => {
-      if (this.accountNumber && !this.loading) {
+      if (!this.loading) {
         console.log('matrix.page: auto-refresh tick');
         this.refresh();
       }
@@ -268,12 +269,13 @@ export class MatrixPage implements OnInit, OnDestroy {
   }
 
   refresh() {
-    if (!this.accountNumber) {
-      return;
-    }
+    // account_number is optional on the backend now (library-only mode
+    // when missing). The page still works — user just sees library
+    // results, no rated mixes, until they set an account.
     this.loading = true;
     this.errorMessage = '';
-    let params = new HttpParams().set('account_number', this.accountNumber);
+    let params = new HttpParams();
+    if (this.accountNumber) params = params.set('account_number', this.accountNumber);
     if (this.sessionFilter) params = params.set('session', this.sessionFilter);
     if (this.q) {
       params = params.set('q', this.q);


### PR DESCRIPTION
Two fixes for the no-session flow.

**home.page.ngOnInit**: the \`prompt(\"Enter show name\")\` path was a second silent no-op. #26 only patched the searchbar; this also catches the prompt. Empty / cancelled → \`router.navigateByUrl('/matrix')\`.

**matrix.page**:
- \`refresh()\` drops the accountNumber guard. Calls /mixes without it; backend (paired [music-k8s #52](https://github.com/nospaceleftondevice/music-k8s/pull/52)) returns library-only.
- Empty-state copy reworked to cover all four combinations of account-set × filters-set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)