### PR TITLE
matrix: stacked dots when a video has multiple ratings

### DIFF
--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.html
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.html
@@ -91,10 +91,20 @@
           <tr *ngFor="let row of matrix; let i = index">
             <th class="row-label" [attr.title]="axisTooltip[i]">{{ axisShort[i] }}</th>
             <td *ngFor="let cell of row" class="cell">
-              <span class="dot"
-                    *ngIf="cellHasDot(cell.rating)"
-                    [style.background]="cellColor(cell.rating)"
-                    [class.bordered]="cellNeedsBorder(cell.rating)">
+              <!-- Stacked dots when multiple raters; single dot when one;
+                   nothing when blank. cell.ratings is sorted desc, top 2
+                   shown. dot-back is offset down-left, dot-front sits on
+                   top of it so the headline rating reads first. -->
+              <span class="dot-stack" *ngIf="cell.ratings && cell.ratings.length">
+                <span class="dot dot-back"
+                      *ngIf="cell.ratings.length > 1"
+                      [style.background]="cellColor(cell.ratings[1])"
+                      [class.bordered]="cellNeedsBorder(cell.ratings[1])">
+                </span>
+                <span class="dot dot-front"
+                      [style.background]="cellColor(cell.ratings[0])"
+                      [class.bordered]="cellNeedsBorder(cell.ratings[0])">
+                </span>
               </span>
             </td>
           </tr>
@@ -118,15 +128,28 @@
       <tbody>
         <tr *ngFor="let p of pairs" [class.is-library]="p.source === 'library'">
           <td class="col-rating">
-            <!-- Rated entries: filled rating dot. Library entries:
-                 small grey "library" badge, no rating number. -->
-            <span *ngIf="p.source === 'rated'" class="dot"
-                  [style.background]="ratingColor(p.rating!)"
-                  [class.bordered]="p.rating === 0">
-              <span class="dot-num">{{ p.rating }}</span>
+            <!-- Three states for the rating column:
+                 (1) Rated entry with one or more ratings → stacked dots,
+                     primary dot shows the headline number (ratings[0]).
+                     Second rating (if any) sits behind, slightly offset.
+                 (2) Rated entry with no ratings (search-mode unrated)
+                     or a library entry → small grey "lib" badge. Both
+                     mean "no rating recorded by anyone." -->
+            <span class="dot-stack" *ngIf="p.ratings && p.ratings.length">
+              <span class="dot dot-back"
+                    *ngIf="p.ratings.length > 1"
+                    [style.background]="ratingColor(p.ratings[1])"
+                    [class.bordered]="p.ratings[1] === 0">
+              </span>
+              <span class="dot dot-front"
+                    [style.background]="ratingColor(p.ratings[0])"
+                    [class.bordered]="p.ratings[0] === 0">
+                <span class="dot-num">{{ p.ratings[0] }}</span>
+              </span>
             </span>
-            <span *ngIf="p.source === 'library'" class="library-badge"
-                  title="From songs.txt library — not yet rated">lib</span>
+            <span class="library-badge"
+                  *ngIf="!p.ratings || !p.ratings.length"
+                  title="Not yet rated by anyone">lib</span>
           </td>
           <td class="col-mix">
             <div class="mix-artist" *ngIf="p.xArtist">{{ p.xArtist }}</div>

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.scss
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.scss
@@ -391,6 +391,47 @@ section h2 {
   text-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
 }
 
+// Stack wrapper holds 1 or 2 absolutely-positioned dots so a video with
+// multiple raters reads as two overlapping circles. Single-rating case
+// just renders one dot (dot-front, no offset). Two-rating case offsets
+// dot-back to the bottom-left and dot-front to the top-right; the
+// front draws on top thanks to DOM order + z-index. Wrapper sized to
+// fit both dots without clipping; inline-block so the table cell
+// vertical-aligns it sensibly.
+.dot-stack {
+  position: relative;
+  display: inline-block;
+  // Big enough for a 22px primary dot offset by 6px ⇒ 28px square.
+  width: 28px;
+  height: 28px;
+  vertical-align: middle;
+}
+
+.dot-stack .dot {
+  position: absolute;
+}
+
+.dot-stack .dot-back {
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+}
+
+.dot-stack .dot-front {
+  top: 0;
+  right: 0;
+  z-index: 2;
+}
+
+// Single-dot variant: when there's only one rating, dot-front is the
+// only child. With no .dot-back to offset against, anchor it to the
+// center so the column doesn't look lop-sided.
+.dot-stack:not(:has(.dot-back)) .dot-front {
+  top: 50%;
+  right: 50%;
+  transform: translate(50%, -50%);
+}
+
 // ---- matrix ----
 //
 // Sized for sessions of ~50+ unique URLs. Each cell is 14px so an 80x80
@@ -518,4 +559,12 @@ $matrix-row-label-width: 96px;
   width: $matrix-dot;
   height: $matrix-dot;
   line-height: $matrix-dot;
+}
+
+// Matrix-cell variant of .dot-stack. Cell is only 14px so the stack
+// can't be 28px — shrink to cell size and tighten the offset between
+// the two dots from 6px down to ~3px.
+.cell .dot-stack {
+  width: $matrix-cell;
+  height: $matrix-cell;
 }

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.ts
@@ -21,8 +21,8 @@ import { ToastController } from '@ionic/angular';
  */
 
 interface MatrixVideo {
-  // 'rated' = videos table, has rating + possibly URLs
-  // 'library' = song_metadata_lookup seed, no rating, no source URLs
+  // 'rated' = videos table, may or may not have a rating
+  // 'library' = song_metadata_lookup seed, never has a rating
   source: 'rated' | 'library';
   id: number | null;
   session: string | null;
@@ -34,7 +34,11 @@ interface MatrixVideo {
   y_title: string | null;
   x_artist: string | null;
   y_artist: string | null;
-  rating: number | null;
+  rating: number | null;  // = ratings[0] for backward compat / convenience
+  // ALL ratings (any account) sorted desc. Frontend stacks ratings[1]
+  // behind ratings[0] to show "multiple people rated this".
+  // Empty array when nobody has rated (search-mode unrated, or library).
+  ratings: number[];
 }
 
 interface MixesResponse {
@@ -59,10 +63,12 @@ interface PairRow {
   xArtist: string | null;
   yArtist: string | null;
   rating: number | null;
+  ratings: number[];
 }
 
 interface MatrixCell {
-  rating: number | null;  // null = no mix at this pair
+  rating: number | null;  // = ratings[0] when present; null when no mix or unrated
+  ratings: number[];      // top ratings across all videos placed in this cell, sorted desc
   videoIds: number[];     // 0+ videos at this pair
 }
 
@@ -335,8 +341,12 @@ export class MatrixPage implements OnInit, OnDestroy {
         xArtist: v.x_artist,
         yArtist: v.y_artist,
         rating: v.rating,
+        ratings: v.ratings || [],
       }))
-      .sort((a, b) => (b.rating! - a.rating!) || (a.videoId! - b.videoId!));
+      // Rated (non-null rating) first by rating desc; unrated rated-source
+      // rows (search mode) come after by id. nullish rating coerces to -1
+      // for the sort key.
+      .sort((a, b) => ((b.rating ?? -1) - (a.rating ?? -1)) || (a.videoId! - b.videoId!));
     const libraryRows: PairRow[] = library
       .map((v) => ({
         source: 'library' as const,
@@ -352,6 +362,7 @@ export class MatrixPage implements OnInit, OnDestroy {
         xArtist: v.x_artist,
         yArtist: v.y_artist,
         rating: null,
+        ratings: [],
       }))
       .sort((a, b) => a.filename.localeCompare(b.filename));
     this.pairs = [...ratedRows, ...libraryRows];
@@ -450,7 +461,7 @@ export class MatrixPage implements OnInit, OnDestroy {
     for (let i = 0; i < n; i++) {
       const row: MatrixCell[] = [];
       for (let j = 0; j < n; j++) {
-        row.push({ rating: null, videoIds: [] });
+        row.push({ rating: null, ratings: [], videoIds: [] });
       }
       cells.push(row);
     }
@@ -471,7 +482,10 @@ export class MatrixPage implements OnInit, OnDestroy {
     const idx = new Map<string, number>();
     sortedAxis.forEach((u, i) => idx.set(u, i));
 
-    // Place rated entries on the matrix as today.
+    // Place rated entries on the matrix. Each video contributes its full
+    // ratings[] into the cell; we keep all ratings sorted desc so the
+    // cell can render stacked dots (ratings[0] in front, ratings[1] behind
+    // when there are multiple raters across the video(s) at this pair).
     for (const v of rated) {
       if (!v.x_url || !v.y_url) continue;
       const i = idx.get(v.x_url);
@@ -480,11 +494,18 @@ export class MatrixPage implements OnInit, OnDestroy {
       if (this.strict && needle) {
         if (!urlMatchesQ(v.x_url) || !urlMatchesQ(v.y_url)) continue;
       }
+      // Pull contributing ratings out once. Empty for unrated videos —
+      // they still get a cell entry (videoId) but no dots; the cell
+      // will render blank.
+      const contributing = v.ratings && v.ratings.length ? v.ratings : [];
       for (const [a, b] of [[i, j], [j, i]] as [number, number][]) {
         const cell = cells[a][b];
-        cell.videoIds.push(v.id!);
-        if (cell.rating === null || v.rating! > cell.rating) {
-          cell.rating = v.rating!;
+        if (v.id !== null) cell.videoIds.push(v.id);
+        if (contributing.length) {
+          cell.ratings.push(...contributing);
+          // Keep sorted desc so cell.ratings[0] is the headline.
+          cell.ratings.sort((a, b) => b - a);
+          cell.rating = cell.ratings[0];
         }
       }
     }


### PR DESCRIPTION
Pairs with [music-k8s #54](https://github.com/nospaceleftondevice/music-k8s/pull/54).

Backend now returns \`ratings: number[]\` per video (sorted desc, all accounts). When a video has **≥2 ratings**, the matrix cell and pair list rating column render TWO dots stacked:

- \`ratings[1]\` behind, offset bottom-left
- \`ratings[0]\` on top, offset top-right (headline number)

Single rating → one centered dot (looks the same as today). Zero ratings → grey \`lib\` badge (applies to library AND search-mode unrated videos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)