### PR TITLE
matrix: render aggregated sessions + dup count from backend dedup

### DIFF
--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.html
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.html
@@ -165,7 +165,16 @@
             <div class="mix-title" *ngIf="p.yTitle" [attr.title]="p.yTitle">{{ p.yTitle }}</div>
             <a class="mix-url" *ngIf="p.yUrl" (click)="openUrl(p.yUrl)">{{ p.yShort }}</a>
           </td>
-          <td class="col-session">{{ p.session }}</td>
+          <td class="col-session">
+            <!-- One row may have collapsed multiple videos that share
+                 the same canonical URL pair. Sessions joined, dup count
+                 shown as a small ×N badge when > 1. -->
+            <span *ngIf="p.sessions && p.sessions.length">{{ p.sessions.join(', ') }}</span>
+            <span class="dup-badge" *ngIf="p.dupCount > 1"
+                  [attr.title]="p.dupCount + ' video rows collapsed (same mix in multiple sessions)'">
+              ×{{ p.dupCount }}
+            </span>
+          </td>
           <td class="col-file">{{ p.filename }}</td>
         </tr>
       </tbody>

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.scss
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.scss
@@ -327,7 +327,22 @@ section h2 {
   color: $text-secondary;
   font-size: 11px;
   vertical-align: top !important;
-  white-space: nowrap;
+}
+
+// ×N badge next to a session list when multiple videos collapsed
+// into one row (same canonical URL pair across sessions). Subtle
+// pill, sits inline at end of the session text.
+.dup-badge {
+  display: inline-block;
+  margin-left: 6px;
+  background: $bg-elevated;
+  color: $text-primary;
+  border: 1px solid $border-subtle;
+  border-radius: 8px;
+  padding: 1px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  cursor: help;
 }
 
 .col-file {

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.ts
@@ -25,7 +25,9 @@ interface MatrixVideo {
   // 'library' = song_metadata_lookup seed, never has a rating
   source: 'rated' | 'library';
   id: number | null;
-  session: string | null;
+  session: string | null;       // representative; see `sessions` for full list
+  sessions: string[];           // sessions this canonical mix appears in (dedup)
+  dup_count: number;            // how many video rows collapsed into this entry
   url: string;
   filename: string;
   x_url: string | null;
@@ -35,9 +37,8 @@ interface MatrixVideo {
   x_artist: string | null;
   y_artist: string | null;
   rating: number | null;  // = ratings[0] for backward compat / convenience
-  // ALL ratings (any account) sorted desc. Frontend stacks ratings[1]
-  // behind ratings[0] to show "multiple people rated this".
-  // Empty array when nobody has rated (search-mode unrated, or library).
+  // ALL ratings (any account, any duplicate video) sorted desc.
+  // Frontend stacks ratings[1] behind ratings[0] for stacked dots.
   ratings: number[];
 }
 
@@ -53,7 +54,12 @@ interface PairRow {
   source: 'rated' | 'library';
   videoId: number | null;
   filename: string;
-  session: string | null;
+  // sessions: aggregated across all videos with the same canonical
+  // URL pair. Length 1 = unique to one session; length > 1 = same
+  // musical mix exists in multiple sessions (e.g. forward + -rev
+  // loads). UI shows them comma-separated.
+  sessions: string[];
+  dupCount: number;     // number of video rows collapsed
   xUrl: string | null;
   yUrl: string | null;
   xShort: string | null;
@@ -337,7 +343,13 @@ export class MatrixPage implements OnInit, OnDestroy {
         source: 'rated' as const,
         videoId: v.id,
         filename: v.filename,
-        session: v.session,
+        // Backend dedup gives us a list of sessions per row. Older
+        // responses (pre-PR #61) only have `session`; fall back to
+        // wrapping it so the UI keeps working during a deploy.
+        sessions: v.sessions && v.sessions.length
+          ? v.sessions
+          : (v.session ? [v.session] : []),
+        dupCount: v.dup_count ?? 1,
         xUrl: v.x_url,
         yUrl: v.y_url,
         xShort: v.x_url ? shortenYouTube(v.x_url) : null,
@@ -352,13 +364,14 @@ export class MatrixPage implements OnInit, OnDestroy {
       // Rated (non-null rating) first by rating desc; unrated rated-source
       // rows (search mode) come after by id. nullish rating coerces to -1
       // for the sort key.
-      .sort((a, b) => ((b.rating ?? -1) - (a.rating ?? -1)) || (a.videoId! - b.videoId!));
+      .sort((a, b) => ((b.rating ?? -1) - (a.rating ?? -1)) || ((a.videoId ?? 0) - (b.videoId ?? 0)));
     const libraryRows: PairRow[] = library
       .map((v) => ({
         source: 'library' as const,
         videoId: null,
         filename: v.filename,
-        session: null,
+        sessions: [],
+        dupCount: 1,
         xUrl: null,
         yUrl: null,
         xShort: null,


### PR DESCRIPTION
Pairs with [music-k8s #61](https://github.com/nospaceleftondevice/music-k8s/pull/61). Pair list `Session` column joins all sessions where the same canonical mix appears, plus a `×N` badge when multiple videos collapsed.