### PR TITLE
feed: show session + song info instead of "maxb" + filename

### DIFF
--- a/vendor/github.com/eaabak/ionTok/src/app/pages/home/home.page.html
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/home/home.page.html
@@ -75,8 +75,20 @@
 
   <ion-slides #slides (ionSlideDidChange)="onSlideDidChange()" (ionSlideTouchStart)="onSlideTouchStart()" [options]="slideOpts">
     <ion-slide *ngFor="let video of videoList; let i = index" [attr.id]="video.url">
-      <video loop playsinline muted preload="metadata" style="background-color: #ccc1c5;" src="{{video.url}}" 
-      title="{{video.userName}}" class="{{video.userPic}}"></video>
+      <!--
+        title= and data-mix-info= are not for the user's eyes here — they
+        carry text that pauseInactiveSlides() reads back via getAttribute
+        and renders into the absolute-positioned project/description
+        overlay at the bottom of each slide. Title was hardcoded to
+        userName (=== literal "maxb" from the backend); now it's the
+        loaded session name. Description was the mp4 filename
+        (video.userPic); now it's "Artist – Title × Artist – Title"
+        composed from the new x_/y_ metadata fields (mixInfo helper
+        falls back to the filename when no metadata was extracted).
+      -->
+      <video loop playsinline muted preload="metadata" style="background-color: #ccc1c5;" src="{{video.url}}"
+      [attr.title]="video.session || video.userName"
+      [attr.data-mix-info]="mixInfo(video)"></video>
       <!--button (click)="loadMoreVideos()" style="position: absolute; top: 20px; left: 10px">Load More</button-->
       <app-feed *ngIf="i !== 0" [video]="video" (rated)="onFeedRated($event)"></app-feed>
       <app-footer [video]="video"></app-footer>

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/home/home.page.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/home/home.page.ts
@@ -884,8 +884,11 @@ export class HomePage implements OnInit {
         //console.log("Current video: ");
         //console.dir(current_video);
         if (index > 0 && current_video !== null) {
-           project.innerText = current_video.getAttribute('title') === null ? "" : current_video.getAttribute('title');
-           description.innerText = current_video.getAttribute('class') === null ? "" : current_video.getAttribute('class');
+           // The title attribute carries the session name; data-mix-info
+           // carries the composed song description (see the binding
+           // comment in home.page.html).
+           project.innerText = current_video.getAttribute('title') || '';
+           description.innerText = current_video.getAttribute('data-mix-info') || '';
            description.style.width = "87%";
            description.style.textAlign = "left";
         }
@@ -955,6 +958,27 @@ refreshProgress() {
       console.error('home.page.ts refreshProgress failed:', err);
     },
   );
+}
+
+// Compose a human-readable mix description from the backend's per-track
+// metadata. Backend (music-k8s /videos) returns x_/y_ artist + title
+// extracted from the mp4 atoms with a YouTube oEmbed backfill; either
+// pair may be missing for older mp4s. Falls back to the filename so the
+// overlay isn't blank when neither half had a hit.
+mixInfo(video: any): string {
+  if (!video) { return ''; }
+  const x = this.formatTrack(video.x_artist, video.x_title);
+  const y = this.formatTrack(video.y_artist, video.y_title);
+  if (x && y) { return `${x} × ${y}`; }
+  if (x || y) { return x || y; }
+  return video.userPic || '';
+}
+
+private formatTrack(artist: string, title: string): string {
+  const a = (artist || '').trim();
+  const t = (title || '').trim();
+  if (a && t) { return `${a} – ${t}`; }
+  return a || t || '';
 }
 
 // Bumped by ionSlideTouchStart on the slider. Gates the scroll-past

--- a/vendor/github.com/eaabak/ionTok/src/app/services/data.service.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/services/data.service.ts
@@ -49,6 +49,17 @@ export class DataService {
                         userPic: video.userPic || '',
                         showcase_url: video.showcase_url || '',
                         id: video.id || '',
+                        // Backend additions (music-k8s #69): the session name
+                        // and per-track metadata used by the feed overlay to
+                        // show "<session>" up top and "Artist – Title × Artist
+                        // – Title" as the description (falls back to userPic
+                        // when both halves are NULL). Falsy-pass-through so
+                        // older backends still work.
+                        session: video.session || '',
+                        x_title: video.x_title || '',
+                        y_title: video.y_title || '',
+                        x_artist: video.x_artist || '',
+                        y_artist: video.y_artist || '',
                     }));
                     console.dir(video_map);
                     return video_map;


### PR DESCRIPTION
## Summary
- The on-feed bottom overlay used to show the literal text "maxb" (from `video.userName`, backend-hardcoded) as the title, and the mp4 filename as the description.
- Now: title shows the **session name** the video was loaded under; description shows **"Artist – Title × Artist – Title"** composed from the new song-metadata fields returned by music-k8s `/videos` (companion PR nospaceleftondevice/music-k8s#69).
- Description carrier moved from `class=` to `data-mix-info=` so song-title words don't end up as CSS classes on the `<video>` element.
- Fallback: if neither half has metadata (older mp4s with no atoms + no oEmbed hit), the filename is shown so the overlay isn't blank.

## Why
"maxb" is meaningless to anyone using the site to rate mixes — it's a vestige of the upstream hardcoded value. Replacing it with the real session and per-mix info makes the feed actually identify what's being rated.

## Test plan
- [ ] Backend PR #69 deployed first (the new fields exist on `/videos`)
- [ ] Open the home feed for a session with extracted metadata — overlay shows `<session>` on top and `Artist – Title × Artist – Title` below
- [ ] Open the home feed for a session where some mp4s have NULL metadata — those videos fall back to the filename (no crash, no blank)
- [ ] Companion music-k8s pin bump merged + deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)