### PR TITLE
feed: reverse-list arrow; matrix: link mp4 filename

### DIFF
--- a/vendor/github.com/eaabak/ionTok/src/app/components/feed/feed.component.html
+++ b/vendor/github.com/eaabak/ionTok/src/app/components/feed/feed.component.html
@@ -51,8 +51,18 @@
     </p>
   </div>
    
-  <div (click)="buttonClicked($event,'info',video.id)" style="margin-bottom: 36px;">
-    <ion-icon size="large" name="information-circle-outline"></ion-icon>
+  <!--
+    Reverse-list arrow. Replaced the old info icon (which did nothing —
+    'info' had no branch in buttonClicked, click just no-op'd). Default
+    is chevron-down: video list is in normal order (you're scrolling
+    through it forward). Tap once → chevron-up, parent reverses the
+    list so you can read from the bottom up. listReversed comes from
+    home.page so the icon stays in sync across all feed instances.
+  -->
+  <div (click)="toggleListDirection($event)" style="margin-bottom: 36px;"
+       [attr.aria-label]="listReversed ? 'Show list in normal order' : 'Reverse list (read from bottom)'">
+    <ion-icon size="large"
+              [name]="listReversed ? 'chevron-up-outline' : 'chevron-down-outline'"></ion-icon>
   </div>
 </div>
 

--- a/vendor/github.com/eaabak/ionTok/src/app/components/feed/feed.component.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/components/feed/feed.component.ts
@@ -11,10 +11,19 @@ import { HttpClient } from '@angular/common/http'; // Import HttpClient
 export class FeedComponent implements OnInit {
   @Input() video: any;
 
+  // Whether the parent's videoList is currently in reversed order.
+  // Drives the chevron icon direction (down = normal, up = reversed)
+  // so every feed instance stays in sync as the user scrolls.
+  @Input() listReversed: boolean = false;
+
   // Fires when the user taps a star on this feed's video. Parent
   // (home.page) tracks the videoIds it has heard from so the
   // scroll-past hook does not also record a 0 for the same video.
   @Output() rated = new EventEmitter<number>();
+
+  // Fires when the user taps the chevron arrow. Parent reverses
+  // videoList and re-anchors the current slide.
+  @Output() reverseToggled = new EventEmitter<void>();
 
   option: AnimationOptions = {
     path: './assets/animations/music.json'
@@ -93,6 +102,14 @@ export class FeedComponent implements OnInit {
           console.error('feed.component.ts: remoteLike Request failed:', error);
         }
       );
+  }
+
+  // Tap-arrow handler. Just tells the parent — home.page does the
+  // actual array reverse + slideTo re-anchor. Stop propagation so
+  // the swipe-up gesture / underlying video click don't also fire.
+  toggleListDirection(event: MouseEvent) {
+    event.stopPropagation();
+    this.reverseToggled.emit();
   }
 
   buttonClicked(event: MouseEvent, button: string, video_id: number) {

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/home/home.page.html
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/home/home.page.html
@@ -90,7 +90,9 @@
       [attr.title]="video.session || video.userName"
       [attr.data-mix-info]="mixInfo(video)"></video>
       <!--button (click)="loadMoreVideos()" style="position: absolute; top: 20px; left: 10px">Load More</button-->
-      <app-feed *ngIf="i !== 0" [video]="video" (rated)="onFeedRated($event)"></app-feed>
+      <app-feed *ngIf="i !== 0" [video]="video" [listReversed]="videoListReversed"
+                (rated)="onFeedRated($event)"
+                (reverseToggled)="toggleVideoListOrder()"></app-feed>
       <app-footer [video]="video"></app-footer>
     </ion-slide>
 

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/home/home.page.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/home/home.page.ts
@@ -30,6 +30,13 @@ export class HomePage implements OnInit {
   currentPage: number = 1;
   limit: number = 10;
 
+  // Drives the chevron arrow in each <app-feed>. false = list rendered
+  // in normal order (chevron-down); true = reversed (chevron-up,
+  // "read from the bottom up"). Toggled by toggleVideoListOrder() —
+  // we reverse videoList in place and re-anchor the current slide so
+  // the user stays on the same video they were watching.
+  videoListReversed: boolean = false;
+
   // Set of video ids the user has explicitly rated (any 1-5 tap)
   // during this page-load. Used by the scroll-past hook in
   // onSlideDidChange so we do not record a 0 for a video the user
@@ -942,6 +949,39 @@ export class HomePage implements OnInit {
         //console.log(`Active index ${activeIndex}`);
     });
   }
+
+// Called by app-feed when the user taps the chevron arrow under
+// the bookmark icon. Reverses the videoList in place, toggles the
+// arrow direction (all feed instances re-render via [listReversed]),
+// and re-anchors the current slide so the user stays on the same
+// video they were watching. The next slide change advances them
+// through the list in the new direction.
+//
+// lastSlideIndex is updated so the scroll-past hook doesn't treat
+// the reposition as a forward-skip and record a rating-0 against
+// whatever video lands at the prior index. Programmatic slideTo
+// also fires ionSlideDidChange — touchSequence is left untouched
+// so the existing user-initiated-only gate continues to drop it.
+toggleVideoListOrder() {
+  if (!this.slides) {
+    this.videoListReversed = !this.videoListReversed;
+    this.videoList = (this.videoList || []).slice().reverse();
+    return;
+  }
+  this.slides.getActiveIndex().then((currentIndex: number) => {
+    const len = (this.videoList || []).length;
+    this.videoList = (this.videoList || []).slice().reverse();
+    this.videoListReversed = !this.videoListReversed;
+    const newIndex = len > 0 ? (len - 1 - currentIndex) : 0;
+    this.lastSlideIndex = newIndex;
+    // ion-slides needs a tick after *ngFor rebuilds the slides before
+    // slideTo() can land on the new index.
+    setTimeout(() => {
+      if (this.slides) { this.slides.slideTo(newIndex, 0); }
+    }, 0);
+    console.log(`home.page.ts toggleVideoListOrder reversed=${this.videoListReversed}, ${currentIndex}→${newIndex}`);
+  });
+}
 
 // Called by app-feed when the user taps any star (1-5). We just
 // remember the video id so the scroll-past hook (below) does not

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.html
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.html
@@ -189,7 +189,15 @@
               ×{{ p.dupCount }}
             </span>
           </td>
-          <td class="col-file">{{ p.filename }}</td>
+          <td class="col-file">
+            <!-- mp4Url links straight to the served file. The xUrl/yUrl
+                 columns above point to source YouTube videos; this one
+                 plays the actual rated mp4 (useful when YT URLs are
+                 missing — for ffmpeg-generated files the mp4 is the
+                 only thing to click). -->
+            <a class="mix-url" *ngIf="p.mp4Url" (click)="openUrl(p.mp4Url)">{{ p.filename }}</a>
+            <span *ngIf="!p.mp4Url">{{ p.filename }}</span>
+          </td>
         </tr>
       </tbody>
     </table>

--- a/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.ts
+++ b/vendor/github.com/eaabak/ionTok/src/app/pages/matrix/matrix.page.ts
@@ -58,6 +58,12 @@ interface PairRow {
   source: 'rated' | 'library';
   videoId: number | null;
   filename: string;
+  // Direct link to the served mp4 (https://coin.computer/Videos/<filename>).
+  // Surfaces in the pair list's File column so the user can open the
+  // actual rated video — used to be implicit ("filename is shown as
+  // text") but rated rows without YT URLs had no other way to play
+  // back the file.
+  mp4Url: string | null;
   // sessions: aggregated across all videos with the same canonical
   // URL pair. Length 1 = unique to one session; length > 1 = same
   // musical mix exists in multiple sessions (e.g. forward + -rev
@@ -347,6 +353,7 @@ export class MatrixPage implements OnInit, OnDestroy {
         source: 'rated' as const,
         videoId: v.id,
         filename: v.filename,
+        mp4Url: v.url || null,
         // Backend dedup gives us a list of sessions per row. Older
         // responses (pre-PR #61) only have `session`; fall back to
         // wrapping it so the UI keeps working during a deploy.
@@ -374,6 +381,7 @@ export class MatrixPage implements OnInit, OnDestroy {
         source: 'library' as const,
         videoId: null,
         filename: v.filename,
+        mp4Url: v.url || null,
         sessions: [],
         dupCount: 1,
         xUrl: null,


### PR DESCRIPTION
## Summary
- **feed: reverse-list arrow.** The info icon under the bookmark (which did nothing — 'info' had no `buttonClicked` branch) is now a chevron arrow. Default chevron-down = list normal; tap → chevron-up + `videoList` reversed in place so the user reads from the bottom up. State (`videoListReversed`) lives on `home.page` and is pushed to every `<app-feed>` via `[listReversed]` so the icon stays in sync across all slides. `toggleVideoListOrder` re-anchors via `slideTo(len-1-currentIndex, 0)` so the user stays on the same video; `lastSlideIndex` is updated so the scroll-past hook doesn't record a phantom rating-0 on the reposition.
- **matrix: mp4 file link.** The pair list's File column was plain text; now it's a clickable link to the served mp4 (`v.url`) when present. The existing xUrl/yUrl columns link to source YouTube videos; this one plays the actual rated file — the only playback option for ffmpeg-generated mp4s that never had source URLs extracted (e.g. session 84-102-jun-11-24).

## Test plan
- [ ] After deploy, feed page: chevron points down by default
- [ ] Tap the chevron: it flips up, list reverses, you stay on the same video
- [ ] Tap again: flips back down, list is in original order
- [ ] Matrix page (`/matrix?session=84-102-jun-11-24`): the File column entries are clickable; clicking opens the mp4 in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)